### PR TITLE
Fix PyPI token secret name in on-release-main workflow

### DIFF
--- a/.github/workflows/on-release-main.yml
+++ b/.github/workflows/on-release-main.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Publish package
         run: uv publish
         env:
-          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
+          UV_PUBLISH_TOKEN: ${{ secrets.PYPI_API_TOKEN }}
 
   deploy-docs:
     needs: publish


### PR DESCRIPTION
Fix PyPI token secret name in on-release-main workflow