### PR TITLE
Fix GitHub release permissions in publish workflow

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -9,7 +9,7 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write  # Required to create GitHub releases
       id-token: write  # Required for trusted publishing (optional)
 
     steps:


### PR DESCRIPTION
Fix GitHub release permissions in publish workflow