### PR TITLE
Add final proof verification for complete assembled proofs

### DIFF
--- a/goedels_poetry/cli.py
+++ b/goedels_poetry/cli.py
@@ -138,6 +138,8 @@ def process_theorems_from_directory(
             output_file = theorem_file.with_suffix(".proof")
             if state_manager.reason == "Proof completed successfully.":
                 try:
+                    # Note: Final verification already performed in framework.finish()
+                    # No need to verify again here
                     complete_proof = state_manager.reconstruct_complete_proof()
                     output_file.write_text(complete_proof, encoding="utf-8")
                     console.print(f"[bold green]✓ Successfully proved and saved to {output_file.name}[/bold green]")


### PR DESCRIPTION
Introduce a final verification step that checks complete proofs (assembled from multiple subgoals) using the Kimina Lean server before they are printed to the terminal or written to files. This ensures that the final assembled proof actually proves the desired theorem, catching any issues that might arise during proof reconstruction from subgoals.

Changes:
- Add check_complete_proof() function in proof_checker_agent.py that directly verifies complete proof strings using the Kimina server
- Integrate final verification into framework.finish() method, which runs after successful proof completion and before printing
- Verification results are displayed to the user with clear success/failure messages and error details when applicable

The implementation reuses existing Kimina client infrastructure and avoids fragile parsing by passing the complete proof (already a valid Lean file) directly to the server for verification.

This addresses the need to verify that proofs assembled from multiple subgoals are indeed valid before presenting them to the user.