### PR TITLE
Add debug logging for vector database responses

### DIFF
--- a/goedels_poetry/agents/util/debug.py
+++ b/goedels_poetry/agents/util/debug.py
@@ -80,6 +80,30 @@ def log_kimina_response(operation: str, response: dict[str, Any]) -> None:
     _debug_console.print(Panel(syntax, title=title, border_style="magenta"))
 
 
+def log_vectordb_response(operation: str, response: list[Any]) -> None:
+    """
+    Log a vector database response if debug mode is enabled.
+
+    Parameters
+    ----------
+    operation : str
+        The operation performed (e.g., "search")
+    response : list[dict]
+        The search results from the vector database
+    """
+    if not _DEBUG_ENABLED:
+        return
+
+    title = f"[bold green]VECTOR_DB[/bold green] - {operation}"
+
+    # Format the response nicely
+    import json
+
+    formatted_response = json.dumps(response, indent=2, default=str)
+    syntax = Syntax(formatted_response, "json", theme="monokai", line_numbers=False)
+    _debug_console.print(Panel(syntax, title=title, border_style="green"))
+
+
 def log_debug_message(message: str, style: str = "yellow") -> None:
     """
     Log a general debug message if debug mode is enabled.

--- a/goedels_poetry/agents/vector_db_agent.py
+++ b/goedels_poetry/agents/vector_db_agent.py
@@ -11,6 +11,7 @@ from goedels_poetry.agents.state import (
     DecomposedFormalTheoremState,
     DecomposedFormalTheoremStates,
 )
+from goedels_poetry.agents.util.debug import log_vectordb_response
 
 
 class VectorDBAgentFactory:
@@ -179,6 +180,9 @@ def _query_vectordb(
             "processing_time_ms": processing_time_ms,
         }
         search_results.append(search_result)
+
+    # Log debug response
+    log_vectordb_response("search", search_results)
 
     # Update the state with the search results
     state["search_results"] = search_results


### PR DESCRIPTION
- Add log_vectordb_response() function to debug.py, mirroring the existing log_kimina_response() function
- Integrate vector DB response logging in vector_db_agent.py's _query_vectordb() method
- Log search results when GOEDELS_POETRY_DEBUG environment variable is enabled, formatted as JSON in a green-bordered panel