### PR TITLE
Add theorem hints to proof sketcher and backtrack agents

### DIFF
--- a/goedels_poetry/agents/proof_sketcher_agent.py
+++ b/goedels_poetry/agents/proof_sketcher_agent.py
@@ -11,6 +11,7 @@ from langgraph.types import Send
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
 from goedels_poetry.agents.util.common import (
     LLMParsingError,
+    _format_theorem_hints_section,
     combine_preamble_and_body,
     load_prompt,
     strip_known_preamble,
@@ -112,7 +113,13 @@ def _proof_sketcher(llm: BaseChatModel, state: DecomposedFormalTheoremState) -> 
         # If it is, load the prompt used when not correcting a previous proof sketch
         # Combine the stored preamble with the formal theorem for the prompt
         formal_theorem_with_imports = combine_preamble_and_body(state["preamble"], state["formal_theorem"])
-        prompt = load_prompt("decomposer-initial", formal_theorem=formal_theorem_with_imports)
+        # Format theorem hints section from search results
+        theorem_hints_section = _format_theorem_hints_section(state["search_results"])
+        prompt = load_prompt(
+            "decomposer-initial",
+            formal_theorem=formal_theorem_with_imports,
+            theorem_hints_section=theorem_hints_section,
+        )
 
         # Put the prompt in the final message
         state["decomposition_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/sketch_backtrack_agent.py
+++ b/goedels_poetry/agents/sketch_backtrack_agent.py
@@ -4,7 +4,7 @@ from langgraph.graph.state import CompiledStateGraph
 from langgraph.types import Send
 
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
-from goedels_poetry.agents.util.common import load_prompt
+from goedels_poetry.agents.util.common import _format_theorem_hints_section, load_prompt
 
 
 class SketchBacktrackAgentFactory:
@@ -84,10 +84,13 @@ def _backtrack(state: DecomposedFormalTheoremState) -> DecomposedFormalTheoremSt
         A DecomposedFormalTheoremStates containing in its outputs the modified
         DecomposedFormalTheoremState
     """
+    # Format theorem hints section from search results
+    theorem_hints_section = _format_theorem_hints_section(state["search_results"])
     # Construct the prompt for backtracking
     prompt = load_prompt(
         "decomposer-backtrack",
         prev_round_num=str(state["self_correction_attempts"]),
+        theorem_hints_section=theorem_hints_section,
     )
 
     # Add backtrack request to the state's decomposition_history

--- a/goedels_poetry/data/prompts/decomposer-backtrack.md
+++ b/goedels_poetry/data/prompts/decomposer-backtrack.md
@@ -10,3 +10,7 @@ Before producing the new Lean 4 code to sketch a proof, provide:
 1. A brief analysis of why the previous decomposition might have been too difficult
 2. A description of the new strategy you will try
 3. An explanation of how this new approach differs from the previous one
+
+{{ theorem_hints_section }}
+
+Note that the theorems listed above may differ from those presented in previous attempts, as a new search strategy was used to find potentially useful theorems for this different decomposition approach. These theorems may or may not be new compared to previous attempts, but they represent theorems identified specifically for trying this alternative strategy. Consider how these theorems might be useful in your new decomposition approach.

--- a/goedels_poetry/data/prompts/decomposer-initial.md
+++ b/goedels_poetry/data/prompts/decomposer-initial.md
@@ -10,6 +10,16 @@ You are a Lean 4 formal theorem prover assistant. Your task is to take a Lean th
 8. Do not introduce auxiliary lemmas or any other statements not subordinate to the main Lean 4 theorem.
 9. In particular do not introduce an unexpected identifier or unexpected command such as "Complex" before the main Lean 4 theorem statement.
 
+{{ theorem_hints_section }}
+
+When decomposing the proof, you may find it helpful to use existing proven theorems from the list above. For example:
+- You might use an existing theorem like `Nat.add_comm` to simplify expressions involving addition
+- You might apply a theorem about inequalities to establish relationships between terms
+- You might use a theorem about properties of functions to transform the goal into a more manageable form
+- You might combine multiple existing theorems to build up to the desired conclusion
+
+Consider how these existing theorems might be incorporated into your proof sketch, either directly in the decomposition or as intermediate steps that help establish the subgoals.
+
 Example input theorem:
 
 ```lean4


### PR DESCRIPTION
This enhancement provides hints to the proof sketcher and sketch backtrack agents by including existing proven theorems from search results in their prompts. This helps guide the decomposition strategy by suggesting relevant theorems that may be useful in proving the target theorem.

Changes:
- Add _format_theorem_hints_section() function and helper functions in agents/util/common.py to format search results into theorem hints
- Update decomposer-initial.md prompt to include {{ theorem_hints_section }} template variable with instructions on using existing theorems
- Update decomposer-backtrack.md prompt to include {{ theorem_hints_section }} template variable with note about potentially new theorems for different strategy
- Update proof_sketcher_agent.py to generate and pass theorem hints section when loading the initial decomposition prompt
- Update sketch_backtrack_agent.py to generate and pass theorem hints section when loading the backtrack prompt

The implementation:
- Formats up to 5 theorems per query, ordered by utility
- Only shows queries with valid results
- Skips results missing required fields (primary_declaration.lean_name, informal_description, statement_text)
- Groups theorems by query with clear separation
- Handles None/empty search_results gracefully