### PR TITLE
Add prompt logging for LLM agents when GOEDELS_POETRY_DEBUG is enabled

### DIFF
--- a/goedels_poetry/agents/formalizer_agent.py
+++ b/goedels_poetry/agents/formalizer_agent.py
@@ -11,7 +11,7 @@ from langgraph.graph.state import CompiledStateGraph
 
 from goedels_poetry.agents.state import InformalTheoremState
 from goedels_poetry.agents.util.common import LLMParsingError, load_prompt, remove_default_imports
-from goedels_poetry.agents.util.debug import log_llm_response
+from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
 
 
 class FormalizerAgentFactory:
@@ -94,6 +94,9 @@ def _formalizer(llm: BaseChatModel, state: InformalTheoremState) -> InformalTheo
         formal_statement_name=f"theorem_{hashed_informal_statement}",
         informal_statement=state["informal_theorem"],
     )
+
+    # Log debug prompt
+    log_llm_prompt("FORMALIZER_AGENT", prompt, "goedel-formalizer-v2")
 
     # Formalize informal statement
     response_content = llm.invoke(prompt).content

--- a/goedels_poetry/agents/informal_theorem_semantics_agent.py
+++ b/goedels_poetry/agents/informal_theorem_semantics_agent.py
@@ -6,7 +6,7 @@ from langgraph.graph.state import CompiledStateGraph
 
 from goedels_poetry.agents.state import InformalTheoremState
 from goedels_poetry.agents.util.common import DEFAULT_IMPORTS, combine_preamble_and_body, load_prompt
-from goedels_poetry.agents.util.debug import log_llm_response
+from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
 from goedels_poetry.agents.util.kimina_server import parse_semantic_check_response
 
 
@@ -89,6 +89,9 @@ def _check_semantics(llm: BaseChatModel, state: InformalTheoremState) -> Informa
         formal_statement=formal_statement_with_imports,
         informal_statement=str(state["informal_theorem"]),
     )
+
+    # Log debug prompt
+    log_llm_prompt("SEMANTICS_AGENT", prompt, "goedel-semiotician-v2")
 
     # Determine if the semantics of the informal and formal theorems are the same
     response_content = llm.invoke(prompt).content

--- a/goedels_poetry/agents/proof_corrector_agent.py
+++ b/goedels_poetry/agents/proof_corrector_agent.py
@@ -5,6 +5,7 @@ from langgraph.types import Send
 
 from goedels_poetry.agents.state import FormalTheoremProofState, FormalTheoremProofStates
 from goedels_poetry.agents.util.common import load_prompt
+from goedels_poetry.agents.util.debug import log_llm_prompt
 
 
 class ProofCorrectorAgentFactory:
@@ -90,6 +91,9 @@ def _corrector(state: FormalTheoremProofState) -> FormalTheoremProofStates:
         prev_round_num=str(state["self_correction_attempts"] - 1),
         error_message_for_prev_round=str(state["errors"]),
     )
+
+    # Log debug prompt
+    log_llm_prompt("PROOF_CORRECTOR_AGENT", prompt, "goedel-prover-v2-subsequent")
 
     # Add correction request to the state's proof_history
     state["proof_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/proof_sketcher_agent.py
+++ b/goedels_poetry/agents/proof_sketcher_agent.py
@@ -16,7 +16,7 @@ from goedels_poetry.agents.util.common import (
     load_prompt,
     strip_known_preamble,
 )
-from goedels_poetry.agents.util.debug import log_llm_response
+from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
 
 
 class ProofSketcherAgentFactory:
@@ -120,6 +120,9 @@ def _proof_sketcher(llm: BaseChatModel, state: DecomposedFormalTheoremState) -> 
             formal_theorem=formal_theorem_with_imports,
             theorem_hints_section=theorem_hints_section,
         )
+
+        # Log debug prompt
+        log_llm_prompt("PROOF_SKETCHER_AGENT", prompt, "decomposer-initial")
 
         # Put the prompt in the final message
         state["decomposition_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/prover_agent.py
+++ b/goedels_poetry/agents/prover_agent.py
@@ -15,7 +15,7 @@ from goedels_poetry.agents.util.common import (
     load_prompt,
     strip_known_preamble,
 )
-from goedels_poetry.agents.util.debug import log_llm_response
+from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
 
 
 class ProverAgentFactory:
@@ -113,6 +113,9 @@ def _prover(llm: BaseChatModel, state: FormalTheoremProofState) -> FormalTheorem
         # Combine the stored preamble with the formal theorem for the prompt
         formal_statement_with_imports = combine_preamble_and_body(state["preamble"], state["formal_theorem"])
         prompt = load_prompt("goedel-prover-v2-initial", formal_statement=formal_statement_with_imports)
+
+        # Log debug prompt
+        log_llm_prompt("PROVER_AGENT", prompt, "goedel-prover-v2-initial")
 
         # Put the prompt in the final message
         state["proof_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/search_query_agent.py
+++ b/goedels_poetry/agents/search_query_agent.py
@@ -9,7 +9,7 @@ from langgraph.types import Send
 
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
 from goedels_poetry.agents.util.common import LLMParsingError, combine_preamble_and_body, load_prompt
-from goedels_poetry.agents.util.debug import log_llm_response
+from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
 
 
 class SearchQueryAgentFactory:
@@ -145,8 +145,12 @@ def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremSt
     if is_backtracking:
         # Use backtrack prompt - the full history is already in decomposition_history
         prompt = load_prompt("search-query-backtrack", formal_theorem=formal_theorem_with_imports)
+        # Log debug prompt
+        log_llm_prompt("SEARCH_QUERY_AGENT", prompt, "search-query-backtrack")
     else:
         prompt = load_prompt("search-query-initial", formal_theorem=formal_theorem_with_imports)
+        # Log debug prompt
+        log_llm_prompt("SEARCH_QUERY_AGENT", prompt, "search-query-initial")
 
     # Add the prompt to decomposition_history
     state["decomposition_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/sketch_backtrack_agent.py
+++ b/goedels_poetry/agents/sketch_backtrack_agent.py
@@ -5,6 +5,7 @@ from langgraph.types import Send
 
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
 from goedels_poetry.agents.util.common import _format_theorem_hints_section, load_prompt
+from goedels_poetry.agents.util.debug import log_llm_prompt
 
 
 class SketchBacktrackAgentFactory:
@@ -92,6 +93,9 @@ def _backtrack(state: DecomposedFormalTheoremState) -> DecomposedFormalTheoremSt
         prev_round_num=str(state["self_correction_attempts"]),
         theorem_hints_section=theorem_hints_section,
     )
+
+    # Log debug prompt
+    log_llm_prompt("SKETCH_BACKTRACK_AGENT", prompt, "decomposer-backtrack")
 
     # Add backtrack request to the state's decomposition_history
     state["decomposition_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/sketch_corrector_agent.py
+++ b/goedels_poetry/agents/sketch_corrector_agent.py
@@ -5,6 +5,7 @@ from langgraph.types import Send
 
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
 from goedels_poetry.agents.util.common import load_prompt
+from goedels_poetry.agents.util.debug import log_llm_prompt
 
 
 class SketchCorrectorAgentFactory:
@@ -91,6 +92,9 @@ def _corrector(state: DecomposedFormalTheoremState) -> DecomposedFormalTheoremSt
         prev_round_num=str(state["self_correction_attempts"] - 1),
         error_message_for_prev_round=str(state["errors"]),
     )
+
+    # Log debug prompt
+    log_llm_prompt("SKETCH_CORRECTOR_AGENT", prompt, "decomposer-subsequent")
 
     # Add correction request to the state's decomposition_history
     state["decomposition_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/util/debug.py
+++ b/goedels_poetry/agents/util/debug.py
@@ -1,4 +1,4 @@
-"""Debug utilities for logging LLM and Kimina server responses."""
+"""Debug utilities for logging LLM prompts, responses, and Kimina server responses."""
 
 from __future__ import annotations
 
@@ -26,6 +26,39 @@ def is_debug_enabled() -> bool:
         True if debug mode is enabled, False otherwise.
     """
     return _DEBUG_ENABLED
+
+
+def log_llm_prompt(agent_name: str, prompt: str, prompt_name: str | None = None) -> None:
+    """
+    Log an LLM prompt if debug mode is enabled.
+
+    Parameters
+    ----------
+    agent_name : str
+        The name of the agent (e.g., "FORMALIZER_AGENT", "PROVER_AGENT")
+    prompt : str
+        The prompt content to be sent to the LLM
+    prompt_name : str, optional
+        The name of the prompt template (e.g., "goedel-formalizer-v2"), by default None
+    """
+    if not _DEBUG_ENABLED:
+        return
+
+    title_parts = [f"[bold yellow]{agent_name}[/bold yellow]"]
+    if prompt_name:
+        title_parts.append(f"prompt: {prompt_name}")
+    else:
+        title_parts.append("prompt")
+    title = " - ".join(title_parts)
+
+    # Try to detect if prompt contains Lean code
+    if "```lean" in prompt or "theorem" in prompt or "lemma" in prompt:
+        # Display as Lean syntax
+        syntax = Syntax(prompt, "lean", theme="monokai", line_numbers=False)
+        _debug_console.print(Panel(syntax, title=title, border_style="yellow"))
+    else:
+        # Display as regular text
+        _debug_console.print(Panel(prompt, title=title, border_style="yellow"))
 
 
 def log_llm_response(agent_name: str, response: str, response_type: str = "response") -> None:


### PR DESCRIPTION
Add a new log_llm_prompt() function to debug.py that logs LLM prompts with syntax highlighting when debug mode is enabled. This complements the existing log_llm_response() function to provide full visibility into the LLM interaction flow.

The function:
- Logs prompts with yellow styling to distinguish from responses (cyan)
- Detects Lean code and applies syntax highlighting
- Includes optional prompt template name for better identification

Integrated prompt logging into all 8 agent files that use load_prompt():
- prover_agent.py (goedel-prover-v2-initial)
- formalizer_agent.py (goedel-formalizer-v2)
- informal_theorem_semantics_agent.py (goedel-semiotician-v2)
- sketch_corrector_agent.py (decomposer-subsequent)
- proof_corrector_agent.py (goedel-prover-v2-subsequent)
- proof_sketcher_agent.py (decomposer-initial)
- search_query_agent.py (search-query-backtrack, search-query-initial)
- sketch_backtrack_agent.py (decomposer-backtrack)

All logging calls are placed immediately after load_prompt() and before the prompt is used, ensuring accurate logging of what is sent to the LLM.