### PR TITLE
Improve theorem hints section formatting and instructions

### DIFF
--- a/goedels_poetry/agents/util/common.py
+++ b/goedels_poetry/agents/util/common.py
@@ -722,10 +722,11 @@ def _format_single_theorem(idx: int, result: dict[str, Any]) -> str:
     statement_text = result.get("statement_text", "")
 
     return (
-        f"{idx}. {lean_name}\n\n"
-        f"Name of the Theorem: {lean_name}\n\n"
-        f"Informal Description of the Theorem: {informal_description}\n\n"
-        f"Formal Statement of the Theorem: {statement_text}\n\n"
+        f"{idx}. {lean_name}\n"
+        f"Name of the Theorem: {lean_name}\n"
+        f"Informal Description of the Theorem: {informal_description}\n"
+        f"Formal Statement of the Theorem:\n"
+        f"```lean4\n{statement_text}\n```\n\n"
     )
 
 

--- a/goedels_poetry/data/prompts/decomposer-backtrack.md
+++ b/goedels_poetry/data/prompts/decomposer-backtrack.md
@@ -5,12 +5,13 @@ Please try a COMPLETELY DIFFERENT decomposition strategy. Consider:
 - A different way to break down the problem into subgoals
 - Different intermediate lemmas that might be easier to prove
 - A simpler or more direct path to the conclusion
+- Utilizing, if warranted, the possibly new theorems listed below in pursuit of your goal
 
 Before producing the new Lean 4 code to sketch a proof, provide:
 1. A brief analysis of why the previous decomposition might have been too difficult
 2. A description of the new strategy you will try
 3. An explanation of how this new approach differs from the previous one
 
-{{ theorem_hints_section }}
+Note that the theorems listed below may differ from those presented in previous attempts, as a new search strategy was used to find potentially useful theorems for this different decomposition approach. These theorems may or may not be new compared to previous attempts, but they represent theorems identified specifically for trying this alternative strategy. Consider how these theorems might be useful in your new decomposition approach.
 
-Note that the theorems listed above may differ from those presented in previous attempts, as a new search strategy was used to find potentially useful theorems for this different decomposition approach. These theorems may or may not be new compared to previous attempts, but they represent theorems identified specifically for trying this alternative strategy. Consider how these theorems might be useful in your new decomposition approach.
+{{ theorem_hints_section }}

--- a/goedels_poetry/data/prompts/decomposer-initial.md
+++ b/goedels_poetry/data/prompts/decomposer-initial.md
@@ -2,23 +2,24 @@ You are a Lean 4 formal theorem prover assistant. Your task is to take a Lean th
 
 1. Think and provide a natural-language proof sketch that explains the reasoning strategy.
 2. Decompose the proof into smaller formal Lean 4 have statements (subgoals) subordinate to the main Lean 4 theorem statement, i.e. contained within the by block of the main Lean 4 theorem.
-3. Output Lean 4 code where each subgoal is expressed as a have statement ending with sorry, so that another prover can attempt to solve them recursively.
-4. Ensure that the top-level Lean 4 theorem does not contain a sorry that is directly subordinate to it.
-5. Ensure that the top-level Lean 4 theorem is entailed by the smaller formal Lean 4 have statements (subgoals) along, possibly, with other Lean 4 code within the by block of the main Lean 4 theorem.
-6. Ensure that later subgoals may assume earlier ones as premises if helpful.
-7. Do not attempt to fully solve the subgoals — only set up the structured decomposition.
-8. Do not introduce auxiliary lemmas or any other statements not subordinate to the main Lean 4 theorem.
-9. In particular do not introduce an unexpected identifier or unexpected command such as "Complex" before the main Lean 4 theorem statement.
+3. When decomposing the proof, use existing proven theorems from the list below if warranted to help establish subgoals or simplify the decomposition.
+4. Output Lean 4 code where each subgoal is expressed as a have statement ending with sorry, so that another prover can attempt to solve them recursively.
+5. Ensure that the top-level Lean 4 theorem does not contain a sorry that is directly subordinate to it.
+6. Ensure that the top-level Lean 4 theorem is entailed by the smaller formal Lean 4 have statements (subgoals) along, possibly, with other Lean 4 code within the by block of the main Lean 4 theorem.
+7. Ensure that later subgoals may assume earlier ones as premises if helpful.
+8. Do not attempt to fully solve the subgoals — only set up the structured decomposition.
+9. Do not introduce auxiliary lemmas or any other statements not subordinate to the main Lean 4 theorem.
+10. In particular do not introduce an unexpected identifier or unexpected command such as "Complex" before the main Lean 4 theorem statement.
 
-{{ theorem_hints_section }}
-
-When decomposing the proof, you may find it helpful to use existing proven theorems from the list above. For example:
+When decomposing the proof, you may find it helpful to use existing proven theorems from the list below. For example:
 - You might use an existing theorem like `Nat.add_comm` to simplify expressions involving addition
 - You might apply a theorem about inequalities to establish relationships between terms
 - You might use a theorem about properties of functions to transform the goal into a more manageable form
 - You might combine multiple existing theorems to build up to the desired conclusion
 
 Consider how these existing theorems might be incorporated into your proof sketch, either directly in the decomposition or as intermediate steps that help establish the subgoals.
+
+{{ theorem_hints_section }}
 
 Example input theorem:
 


### PR DESCRIPTION
- Reorder theorem hints explanation to appear before the placeholder in both decomposer prompts (initial and backtrack) for better readability

- Add explicit instruction to use existing theorems in decomposer-initial.md task list (item 3)

- Add bullet point about utilizing possibly new theorems in decomposer-backtrack.md considerations list

- Update _format_single_theorem() to remove blank lines between theorem elements and wrap formal statements in lean4 code blocks for better formatting

These changes improve the clarity of instructions for using theorem hints and enhance the visual presentation of theorem information in prompts.