### PR TITLE
Remove legacy regex proof reconstruction; make AST/offset splicing definitive

### DIFF
--- a/goedels_poetry/agents/state.py
+++ b/goedels_poetry/agents/state.py
@@ -189,6 +189,28 @@ class DecomposedFormalTheoremState(TypedDict):
         List of search results from the vector database, where search_results[i] corresponds to
         the results from search_queries[i]. None indicates results have not been retrieved yet,
         and an empty list indicates no queries were provided.
+
+    hole_name: Required[str | None]
+        The name of the `sorry` hole in the *parent sketch* that this decomposed node is intended to fill.
+
+        This is propagated when a `FormalTheoremProofState` is replaced by a `DecomposedFormalTheoremState`
+        (i.e., when a proof attempt is deemed too difficult and we decide to sketch+decompose it). It
+        typically matches a `have` identifier, a synthetic anonymous-have name, or the special marker
+        `"<main body>"`.
+
+        For root decompositions (no parent sketch) and for legacy/unknown cases, this is `None`.
+    hole_start: Required[int | None]
+        Character offset (0-based) into the parent sketch **body string** (i.e. `proof_sketch`)
+        indicating the start of the `sorry` token that should be replaced during reconstruction.
+
+        For root decompositions (no parent sketch) and for legacy/unknown cases, this is `None`.
+    hole_end: Required[int | None]
+        Character offset (0-based) into the parent sketch **body string** (i.e. `proof_sketch`)
+        indicating the end of the `sorry` token that should be replaced during reconstruction.
+
+        This is exclusive (Python slicing semantics): the `sorry` span is `proof_sketch[hole_start:hole_end]`.
+
+        For root decompositions (no parent sketch) and for legacy/unknown cases, this is `None`.
     """
 
     # InternalTreeNode specific properties
@@ -207,6 +229,9 @@ class DecomposedFormalTheoremState(TypedDict):
     decomposition_history: Required[Annotated[list[AnyMessage], add]]
     search_queries: Required[list[str] | None]
     search_results: Required[list[APISearchResponseTypedDict] | None]
+    hole_name: Required[str | None]
+    hole_start: Required[int | None]
+    hole_end: Required[int | None]
 
 
 class DecomposedFormalTheoremStates(TypedDict):


### PR DESCRIPTION
This drops the transitional, regex/name-based proof reconstruction path (v1.1.5-era) and makes the v1.1.6 AST-guided, offset-based reconstruction the only supported mechanism.

Reconstruction changes
- Delete all legacy reconstruction helpers and fallbacks in `goedels_poetry/state.py` (`_replace_*`, `_extract_have_name`, anonymous-have regex matching, main-body regex scanning, etc.).
- Reconstruction now *only* splices child proofs into parent sketches using recorded `hole_start/hole_end` spans (body-relative offsets).
- Offset splicing now correctly handles both:
  - standalone hole lines (`    sorry`)
  - inline holes (`... := by sorry`) by rewriting into `... := by\n  <proof>` with correct indentation.
- Preserve hole metadata when a proved leaf is replaced by a decomposed node so nested decomposition
  remains offset-reconstructable end-to-end.

State/type updates
- Add `hole_name/hole_start/hole_end` to `DecomposedFormalTheoremState` (`goedels_poetry/agents/state.py`).

AST/decomposition fixes
- Support the special subgoal marker `"<main body>"` in AST rewriting by treating it as “the enclosing theorem” and synthesizing a stable wrapper name `gp_main_body__<decl>` for subgoal code extraction.

Test suite updates
- Update unit tests to attach hole offsets when building proof trees manually and remove tests that targeted deleted legacy regex helpers.
- Expand Kimina-backed generated reconstruction integration suite to cover:
  - anonymous `have : ...` holes (synthetic `gp_anon_have__<decl>__1` naming)
  - `"<main body>"` holes
  - inline `:= by sorry` holes

Misc
- Make `lean_explore` optional at import-time for vector DB agent (clear runtime error when missing) while keeping ruff/mypy satisfied.

Verification: `make check` passes; full pytest passes; Kimina-generated reconstruction suite passes at full corpus size (720 cases).