### PR TITLE
Fix preamble splitting for files with literal escape sequences

### DIFF
--- a/goedels_poetry/agents/util/common.py
+++ b/goedels_poetry/agents/util/common.py
@@ -86,6 +86,62 @@ _DECLARATION_MODIFIERS: tuple[str, ...] = (
 )
 
 
+def normalize_escape_sequences(content: str) -> str:
+    """
+    Convert literal escape sequences to their actual characters.
+
+    This function converts common escape sequences that appear as literal
+    two-character sequences (e.g., \\n, \\t) in strings to their actual
+    character equivalents (newline, tab, etc.). This is necessary because
+    some input sources may contain escape sequences as literal text rather than
+    actual escape sequences.
+
+    The function handles escaped backslashes (\\\\ -> \\) correctly by
+    processing them appropriately to avoid double conversion.
+
+    Parameters
+    ----------
+    content: str
+        The content that may contain literal escape sequences
+
+    Returns
+    -------
+    str
+        The content with escape sequences converted to actual characters
+    """
+    # Use a character-based approach to handle escaped backslashes correctly
+    # Process character by character to distinguish \\n from \n
+    result = []
+    i = 0
+    while i < len(content):
+        if content[i] == "\\" and i + 1 < len(content):
+            next_char = content[i + 1]
+            if next_char == "\\":
+                # Escaped backslash: preserve as single backslash
+                result.append("\\")
+                i += 2
+            elif next_char == "n":
+                # Literal \n: convert to actual newline
+                result.append("\n")
+                i += 2
+            elif next_char == "t":
+                # Literal \t: convert to actual tab
+                result.append("\t")
+                i += 2
+            elif next_char == "r":
+                # Literal \r: convert to actual carriage return
+                result.append("\r")
+                i += 2
+            else:
+                # Backslash followed by something else: keep as-is
+                result.append(content[i])
+                i += 1
+        else:
+            result.append(content[i])
+            i += 1
+    return "".join(result)
+
+
 def _normalize_block(block: str) -> str:
     """Normalize a multi-line string for comparison."""
     if not block:

--- a/goedels_poetry/cli.py
+++ b/goedels_poetry/cli.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING
 import typer
 from rich.console import Console
 
-from goedels_poetry.agents.util.common import split_preamble_and_body
+from goedels_poetry.agents.util.common import normalize_escape_sequences, split_preamble_and_body
 
 if TYPE_CHECKING:
     from goedels_poetry.state import GoedelsPoetryStateManager
@@ -28,6 +28,8 @@ def _read_theorem_content(theorem_file: Path) -> str | None:
     if not theorem_content:
         console.print(f"[bold yellow]Warning:[/bold yellow] {theorem_file.name} is empty, skipping")
         return None
+    # Normalize escape sequences (e.g., convert literal \n to actual newline)
+    theorem_content = normalize_escape_sequences(theorem_content)
     return theorem_content
 
 
@@ -106,6 +108,8 @@ def process_single_theorem(
     config = GoedelsPoetryConfig()
 
     if formal_theorem:
+        # Normalize escape sequences (e.g., convert literal \n to actual newline)
+        formal_theorem = normalize_escape_sequences(formal_theorem)
         if not _has_preamble(formal_theorem):
             console.print("[bold red]Error:[/bold red] Formal theorems must include a Lean header (imports/options).")
             raise typer.Exit(code=1)


### PR DESCRIPTION
When Lean theorem files or command-line arguments contained literal escape sequences (e.g., \n as two characters: backslash followed by 'n') instead of actual newline characters, the preamble splitting logic would fail because _skip_whitespace() only recognizes actual newline characters.

This caused set_option maxHeartbeats 0 to be incorrectly placed after theorem declarations instead of in the preamble section.

Changes:
- Add normalize_escape_sequences() function to agents.util.common module to convert literal escape sequences (\n, \t, \r) to actual characters
- Apply normalization in _read_theorem_content() when reading files from disk
- Apply normalization in process_single_theorem() when processing command-line arguments passed via --formal-theorem

The function handles escaped backslashes (\\ -> \) correctly to avoid double conversion, ensuring that both literal escape sequences and properly escaped backslashes are processed correctly.