### PR TITLE
Fix type extraction for set_with_hypothesis from earlier sorries

### DIFF
--- a/tests/test_parsers_ast.py
+++ b/tests/test_parsers_ast.py
@@ -6113,7 +6113,7 @@ def test_ast_get_named_subgoal_code_merged_sorries_type_conflict() -> None:
     earlier_sorry = {
         "pos": {"line": 2, "column": 4},
         "endPos": {"line": 2, "column": 9},
-        "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001
+        "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001  # noqa: RUF001
         "proofState": 1,
     }
 
@@ -6239,7 +6239,7 @@ def test_ast_get_named_subgoal_code_no_target_specific_sorry() -> None:
     sorry = {
         "pos": {"line": 2, "column": 4},
         "endPos": {"line": 2, "column": 9},
-        "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001
+        "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001  # noqa: RUF001
         "proofState": 1,
     }
 
@@ -6375,7 +6375,7 @@ def test_ast_get_named_subgoal_code_multiple_set_with_hypothesis() -> None:
     earlier_sorry = {
         "pos": {"line": 2, "column": 4},
         "endPos": {"line": 2, "column": 9},
-        "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001
+        "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001  # noqa: RUF001
         "proofState": 1,
     }
 
@@ -6595,7 +6595,7 @@ def test_ast_get_named_subgoal_code_sorries_with_empty_goals() -> None:
         {
             "pos": {"line": 5, "column": 4},
             "endPos": {"line": 5, "column": 9},
-            "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001
+            "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001  # noqa: RUF001
             "proofState": 2,
         },  # Valid goal
         {"pos": {"line": 7, "column": 4}, "endPos": {"line": 7, "column": 9}, "proofState": 3},  # Missing goal key
@@ -6765,6 +6765,694 @@ def test_ast_get_named_subgoal_code_merge_priority_verification() -> None:
     # Ensure earlier type is NOT present
     hy_wrong_pattern = re.compile(r"hy\s*:\s*y\s*=\s*15\b")
     assert not hy_wrong_pattern.search(result), f"hy should not have earlier type (y = 15). Result: {result}"
+
+
+def test_ast_get_named_subgoal_code_set_with_hypothesis_goal_context_basic() -> None:
+    """
+    Test that set_with_hypothesis type is correctly extracted from goal context.
+
+    Basic test: set binding with 'with' clause, hypothesis type in goal context.
+    """
+    ast_dict = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "test_theorem", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Mathlib.Tactic.setTactic",
+                                "args": [
+                                    {"val": "set", "info": {"leading": "", "trailing": " "}},
+                                    [],
+                                    {
+                                        "kind": "Mathlib.Tactic.setArgsRest",
+                                        "args": [
+                                            {"val": "x", "info": {"leading": "", "trailing": " "}},
+                                            [],
+                                            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "5", "info": {"leading": " ", "trailing": "\n  "}},
+                                            [
+                                                {"val": "with", "info": {"leading": " ", "trailing": " "}},
+                                                [],
+                                                {"val": "hx", "info": {"leading": "", "trailing": "\n  "}},
+                                            ],
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticHave_",
+                                "args": [
+                                    {"val": "have", "info": {"leading": "\n  ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.haveDecl",
+                                        "args": [
+                                            {
+                                                "kind": "Lean.Parser.Term.haveIdDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveId",
+                                                        "args": [
+                                                            {"val": "h1", "info": {"leading": "", "trailing": " "}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                            {"val": ":", "info": {"leading": "", "trailing": " "}},
+                                            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+                                        ],
+                                    },
+                                    {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.byTactic",
+                                        "args": [
+                                            {"val": "by", "info": {"leading": "", "trailing": " "}},
+                                            {
+                                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                        "args": [
+                                                            {"val": "sorry", "info": {"leading": "", "trailing": ""}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    # Sorry with hx type in goal context
+    sorry_with_hx = {
+        "pos": {"line": 5, "column": 4},
+        "endPos": {"line": 5, "column": 9},
+        "goal": "x : ℕ := 5\nhx : x = 5\nh1 : Prop\n⊢ Prop",  # noqa: RUF001
+        "proofState": 1,
+    }
+
+    sorries = [sorry_with_hx]
+
+    ast = AST(ast_dict, sorries)
+    result = ast.get_named_subgoal_code("h1")
+
+    # Should include hx with correct type from goal context
+    assert "h1" in result
+    assert "hx" in result, f"Missing hx hypothesis. Result: {result}"
+    # Should have the equality type, not Prop
+    assert "hx" in result and "x = 5" in result, f"hx should have equality type (x = 5). Result: {result}"
+    assert "hx : Prop" not in result, f"hx should not be typed as Prop. Result: {result}"
+
+
+def test_ast_get_named_subgoal_code_set_with_hypothesis_goal_context_earlier_sorry() -> None:
+    """
+    Test that set_with_hypothesis type from earlier sorry is included.
+
+    The hypothesis type is in an earlier sorry's goal context, not the target-specific one.
+    """
+    ast_dict = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "test_theorem", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Mathlib.Tactic.setTactic",
+                                "args": [
+                                    {"val": "set", "info": {"leading": "", "trailing": " "}},
+                                    [],
+                                    {
+                                        "kind": "Mathlib.Tactic.setArgsRest",
+                                        "args": [
+                                            {"val": "x", "info": {"leading": "", "trailing": " "}},
+                                            [],
+                                            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "10", "info": {"leading": " ", "trailing": "\n  "}},
+                                            [
+                                                {"val": "with", "info": {"leading": " ", "trailing": " "}},
+                                                [],
+                                                {"val": "hx", "info": {"leading": "", "trailing": "\n  "}},
+                                            ],
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticHave_",
+                                "args": [
+                                    {"val": "have", "info": {"leading": "\n  ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.haveDecl",
+                                        "args": [
+                                            {
+                                                "kind": "Lean.Parser.Term.haveIdDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveId",
+                                                        "args": [
+                                                            {"val": "h1", "info": {"leading": "", "trailing": " "}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                            {"val": ":", "info": {"leading": "", "trailing": " "}},
+                                            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+                                        ],
+                                    },
+                                    {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.byTactic",
+                                        "args": [
+                                            {"val": "by", "info": {"leading": "", "trailing": " "}},
+                                            {
+                                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                        "args": [
+                                                            {"val": "sorry", "info": {"leading": "", "trailing": ""}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    # Earlier sorry (main theorem body) - contains hx type
+    earlier_sorry = {
+        "pos": {"line": 2, "column": 4},
+        "endPos": {"line": 2, "column": 9},
+        "goal": "x : ℕ := 10\nhx : x = 10\n⊢ Prop",  # noqa: RUF001
+        "proofState": 1,
+    }
+
+    # Target-specific sorry (for h1) - does NOT contain hx type
+    target_sorry = {
+        "pos": {"line": 5, "column": 4},
+        "endPos": {"line": 5, "column": 9},
+        "goal": "x : ℕ := 10\nh1 : Prop\n⊢ Prop",  # noqa: RUF001
+        "proofState": 2,
+    }
+
+    sorries = [earlier_sorry, target_sorry]
+
+    ast = AST(ast_dict, sorries)
+    result = ast.get_named_subgoal_code("h1")
+
+    # Should include hx with correct type from earlier sorry
+    assert "h1" in result
+    assert "hx" in result, f"Missing hx hypothesis from earlier sorry. Result: {result}"
+    # Should have the equality type from earlier sorry
+    assert "hx" in result and "x = 10" in result, (
+        f"hx should have equality type (x = 10) from earlier sorry. Result: {result}"
+    )
+    assert "hx : Prop" not in result, f"hx should not be typed as Prop. Result: {result}"
+
+
+def test_ast_get_named_subgoal_code_set_with_hypothesis_goal_context_target_sorry_priority() -> None:
+    """
+    Test that set_with_hypothesis type from target-specific sorry takes priority.
+
+    When the same hypothesis appears in both earlier and target-specific sorries,
+    the target-specific sorry's type should be used.
+    """
+    ast_dict = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "test_theorem", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Mathlib.Tactic.setTactic",
+                                "args": [
+                                    {"val": "set", "info": {"leading": "", "trailing": " "}},
+                                    [],
+                                    {
+                                        "kind": "Mathlib.Tactic.setArgsRest",
+                                        "args": [
+                                            {"val": "x", "info": {"leading": "", "trailing": " "}},
+                                            [],
+                                            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "5", "info": {"leading": " ", "trailing": "\n  "}},
+                                            [
+                                                {"val": "with", "info": {"leading": " ", "trailing": " "}},
+                                                [],
+                                                {"val": "hx", "info": {"leading": "", "trailing": "\n  "}},
+                                            ],
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticHave_",
+                                "args": [
+                                    {"val": "have", "info": {"leading": "\n  ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.haveDecl",
+                                        "args": [
+                                            {
+                                                "kind": "Lean.Parser.Term.haveIdDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveId",
+                                                        "args": [
+                                                            {"val": "h1", "info": {"leading": "", "trailing": " "}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                            {"val": ":", "info": {"leading": "", "trailing": " "}},
+                                            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+                                        ],
+                                    },
+                                    {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.byTactic",
+                                        "args": [
+                                            {"val": "by", "info": {"leading": "", "trailing": " "}},
+                                            {
+                                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                        "args": [
+                                                            {"val": "sorry", "info": {"leading": "", "trailing": ""}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    # Earlier sorry with hx : x = 5
+    earlier_sorry = {
+        "pos": {"line": 2, "column": 4},
+        "endPos": {"line": 2, "column": 9},
+        "goal": "x : ℕ := 5\nhx : x = 5\n⊢ Prop",  # noqa: RUF001
+        "proofState": 1,
+    }
+
+    # Target-specific sorry with hx : x = 10 (conflicting type, should take priority)
+    target_sorry = {
+        "pos": {"line": 5, "column": 4},
+        "endPos": {"line": 5, "column": 9},
+        "goal": "x : ℕ := 5\nhx : x = 10\nh1 : Prop\n⊢ Prop",  # noqa: RUF001
+        "proofState": 2,
+    }
+
+    sorries = [earlier_sorry, target_sorry]
+
+    ast = AST(ast_dict, sorries)
+    result = ast.get_named_subgoal_code("h1")
+
+    # Should include hx with target-specific type (x = 10), not earlier type (x = 5)
+    assert "h1" in result
+    assert "hx" in result, f"Missing hx hypothesis. Result: {result}"
+    # Target-specific type should win
+    assert "hx" in result and "x = 10" in result, f"hx should have target-specific type (x = 10). Result: {result}"
+    # Earlier type should NOT be present
+    hx_wrong_pattern = re.compile(r"hx\s*:\s*x\s*=\s*5\b")
+    assert not hx_wrong_pattern.search(result), f"hx should not have earlier type (x = 5). Result: {result}"
+
+
+def test_ast_get_named_subgoal_code_set_with_hypothesis_goal_context_complex_equality() -> None:
+    """
+    Test that complex equality type expressions are correctly parsed from goal context.
+
+    Tests that equality types with complex expressions are preserved correctly.
+    """
+    ast_dict = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "test_theorem", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Mathlib.Tactic.setTactic",
+                                "args": [
+                                    {"val": "set", "info": {"leading": "", "trailing": " "}},
+                                    [],
+                                    {
+                                        "kind": "Mathlib.Tactic.setArgsRest",
+                                        "args": [
+                                            {"val": "S", "info": {"leading": "", "trailing": " "}},
+                                            [],
+                                            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                            {
+                                                "val": "Finset.range 10000",
+                                                "info": {"leading": " ", "trailing": "\n  "},
+                                            },
+                                            [
+                                                {"val": "with", "info": {"leading": " ", "trailing": " "}},
+                                                [],
+                                                {"val": "hS", "info": {"leading": "", "trailing": "\n  "}},
+                                            ],
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticHave_",
+                                "args": [
+                                    {"val": "have", "info": {"leading": "\n  ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.haveDecl",
+                                        "args": [
+                                            {
+                                                "kind": "Lean.Parser.Term.haveIdDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveId",
+                                                        "args": [
+                                                            {"val": "h1", "info": {"leading": "", "trailing": " "}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                            {"val": ":", "info": {"leading": "", "trailing": " "}},
+                                            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+                                        ],
+                                    },
+                                    {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.byTactic",
+                                        "args": [
+                                            {"val": "by", "info": {"leading": "", "trailing": " "}},
+                                            {
+                                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                        "args": [
+                                                            {"val": "sorry", "info": {"leading": "", "trailing": ""}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    # Sorry with complex equality type
+    sorry_with_complex_type = {
+        "pos": {"line": 5, "column": 4},
+        "endPos": {"line": 5, "column": 9},
+        "goal": "S : Finset ℕ := Finset.range 10000\nhS : S = Finset.range 10000\nh1 : Prop\n⊢ Prop",  # noqa: RUF001
+        "proofState": 1,
+    }
+
+    sorries = [sorry_with_complex_type]
+
+    ast = AST(ast_dict, sorries)
+    result = ast.get_named_subgoal_code("h1")
+
+    # Should include hS with complex equality type
+    assert "h1" in result
+    assert "hS" in result, f"Missing hS hypothesis. Result: {result}"
+    # Should have the complex equality type
+    assert "hS" in result and "S = Finset.range 10000" in result, (
+        f"hS should have complex equality type. Result: {result}"
+    )
+    assert "hS : Prop" not in result, f"hS should not be typed as Prop. Result: {result}"
+
+
+def test_ast_get_named_subgoal_code_set_with_hypothesis_goal_context_multiple_hypotheses() -> None:
+    """
+    Test that multiple set_with_hypothesis bindings are correctly handled from goal context.
+
+    Tests that all hypothesis types are collected when there are multiple set ... with h statements.
+    """
+    ast_dict = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "test_theorem", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Mathlib.Tactic.setTactic",
+                                "args": [
+                                    {"val": "set", "info": {"leading": "", "trailing": " "}},
+                                    [],
+                                    {
+                                        "kind": "Mathlib.Tactic.setArgsRest",
+                                        "args": [
+                                            {"val": "x", "info": {"leading": "", "trailing": " "}},
+                                            [],
+                                            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "5", "info": {"leading": " ", "trailing": "\n  "}},
+                                            [
+                                                {"val": "with", "info": {"leading": " ", "trailing": " "}},
+                                                [],
+                                                {"val": "hx", "info": {"leading": "", "trailing": "\n  "}},
+                                            ],
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                "kind": "Mathlib.Tactic.setTactic",
+                                "args": [
+                                    {"val": "set", "info": {"leading": "", "trailing": " "}},
+                                    [],
+                                    {
+                                        "kind": "Mathlib.Tactic.setArgsRest",
+                                        "args": [
+                                            {"val": "y", "info": {"leading": "", "trailing": " "}},
+                                            [],
+                                            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "10", "info": {"leading": " ", "trailing": "\n  "}},
+                                            [
+                                                {"val": "with", "info": {"leading": " ", "trailing": " "}},
+                                                [],
+                                                {"val": "hy", "info": {"leading": "", "trailing": "\n  "}},
+                                            ],
+                                        ],
+                                    },
+                                ],
+                            },
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticHave_",
+                                "args": [
+                                    {"val": "have", "info": {"leading": "\n  ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.haveDecl",
+                                        "args": [
+                                            {
+                                                "kind": "Lean.Parser.Term.haveIdDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveId",
+                                                        "args": [
+                                                            {"val": "h1", "info": {"leading": "", "trailing": " "}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                            {"val": ":", "info": {"leading": "", "trailing": " "}},
+                                            {"val": "Prop", "info": {"leading": "", "trailing": " "}},
+                                        ],
+                                    },
+                                    {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.byTactic",
+                                        "args": [
+                                            {"val": "by", "info": {"leading": "", "trailing": " "}},
+                                            {
+                                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                        "args": [
+                                                            {"val": "sorry", "info": {"leading": "", "trailing": ""}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    # Sorry with both hx and hy types
+    sorry_with_multiple = {
+        "pos": {"line": 5, "column": 4},
+        "endPos": {"line": 5, "column": 9},
+        "goal": "x : ℕ := 5\ny : ℕ := 10\nhx : x = 5\nhy : y = 10\nh1 : Prop\n⊢ Prop",  # noqa: RUF001
+        "proofState": 1,
+    }
+
+    sorries = [sorry_with_multiple]
+
+    ast = AST(ast_dict, sorries)
+    result = ast.get_named_subgoal_code("h1")
+
+    # Should include both hx and hy with correct types
+    assert "h1" in result
+    assert "hx" in result, f"Missing hx hypothesis. Result: {result}"
+    assert "hy" in result, f"Missing hy hypothesis. Result: {result}"
+    # Both should have equality types
+    assert "hx" in result and "x = 5" in result, f"hx should have equality type (x = 5). Result: {result}"
+    assert "hy" in result and "y = 10" in result, f"hy should have equality type (y = 10). Result: {result}"
+    # Neither should be Prop
+    assert "hx : Prop" not in result, f"hx should not be typed as Prop. Result: {result}"
+    assert "hy : Prop" not in result, f"hy should not be typed as Prop. Result: {result}"
+
+
+def test_parse_goal_context_set_with_hypothesis_assignment_syntax() -> None:
+    """
+    Test that __parse_goal_context correctly handles assignment syntax in goal context.
+
+    Tests that lines with := (assignments) are parsed correctly, extracting the type
+    before := rather than treating the whole assignment as a type.
+    """
+    from goedels_poetry.parsers.util import __parse_goal_context
+
+    # Goal context with assignment syntax (variable : type := value)
+    goal = (
+        "OddProd : ℕ := (Finset.filter (fun x => ¬Even x) (Finset.range 10000)).prod id\n"  # noqa: RUF001
+        "hOddProd : OddProd = (Finset.filter (fun x => ¬Even x) (Finset.range 10000)).prod id\n"
+        "⊢ Prop"
+    )
+
+    result = __parse_goal_context(goal)
+
+    # OddProd should have type ℕ (not the assignment)  # noqa: RUF003
+    assert "OddProd" in result
+    assert result["OddProd"] == "ℕ", f"OddProd should have type ℕ, got {result.get('OddProd')}"  # noqa: RUF001
+
+    # hOddProd should have the equality type
+    assert "hOddProd" in result
+    assert "OddProd = " in result["hOddProd"], f"hOddProd should have equality type, got {result.get('hOddProd')}"
+
+    # Should not have spurious entries like ":" or "ℕ" as separate variables  # noqa: RUF003
+    assert ":" not in result, f"Should not have ':' as a variable name. Result: {result}"
+    # Note: ℕ might appear if there are other variables, but it shouldn't be from this line  # noqa: RUF003
+    if "ℕ" in result and result["ℕ"] != "ℕ":  # noqa: RUF001
+        # If ℕ appears, it should be from a different line, not from parsing OddProd's assignment  # noqa: RUF003
+        pass
+
+
+def test_parse_goal_context_set_with_hypothesis_equality_types() -> None:
+    """
+    Test that __parse_goal_context correctly parses equality types for set_with_hypothesis.
+
+    Tests various equality type formats that might appear in goal context.
+    """
+    from goedels_poetry.parsers.util import __parse_goal_context
+
+    # Test case 1: Simple equality
+    goal1 = "hx : x = 5\n⊢ Prop"
+    result1 = __parse_goal_context(goal1)
+    assert "hx" in result1
+    assert result1["hx"] == "x = 5"
+
+    # Test case 2: Equality with complex expression
+    goal2 = "hS : S = Finset.range 10000\n⊢ Prop"
+    result2 = __parse_goal_context(goal2)
+    assert "hS" in result2
+    assert result2["hS"] == "S = Finset.range 10000"
+
+    # Test case 3: Multiple hypotheses with equality types
+    goal3 = "hx : x = 5\nhy : y = 10\nhz : z = x + y\n⊢ Prop"
+    result3 = __parse_goal_context(goal3)
+    assert "hx" in result3 and result3["hx"] == "x = 5"
+    assert "hy" in result3 and result3["hy"] == "y = 10"
+    assert "hz" in result3 and result3["hz"] == "z = x + y"
 
 
 def test_ast_get_named_subgoal_code_exact_key_matching_not_substring() -> None:


### PR DESCRIPTION
This commit addresses warnings about missing types for `set_with_hypothesis` bindings (e.g., `hOddProd`) by improving type information collection from multiple sorries and enhancing goal context parsing.

Key changes:

1. Enhanced type collection in `_get_named_subgoal_rewritten_ast`:
   - Changed from substring matching to exact key matching when identifying target-specific sorries (prevents false positives like "h1" matching "h10")
   - Modified type collection strategy to merge types from all sorries:
     * Collect types from all non-target sorries (first occurrence wins)
     * Identify target-specific sorry using exact key matching in parsed_types * Merge all_types with target_sorry_types, giving priority to target-specific
   - This ensures types from earlier sorries (including `set_with_hypothesis` bindings) are available when processing later subgoals

2. Improved goal context parsing:
   - Refactored `__parse_goal_context` to extract `__parse_goal_context_line` helper function, reducing complexity (C901 fix)
   - Added support for assignment syntax (`name : type := value`) in goal context parsing, correctly extracting the type part before `:=`
   - Enhanced handling of multiple variables with same type declaration

3. Fixed linting issues:
   - Added `# noqa: C901` for complexity warning (resolved via refactoring)
   - Added `# noqa: RUF001` for ambiguous Unicode characters (ℕ) in test strings
   - Added `# noqa: RUF002` for ambiguous Unicode in docstring (replaced with Nat)
   - Added `# noqa: RUF003` for ambiguous Unicode in comments

4. Added comprehensive tests:
   - Tests for exact key matching vs substring matching (h1 vs h10, etc.)
   - Tests for type merging from multiple sorries with conflict resolution
   - Tests for `set_with_hypothesis` type extraction from earlier sorries
   - Tests for assignment syntax parsing in goal context
   - Tests for edge cases (empty sorries, missing goals, etc.)

This fixes the issue where `hOddProd` and similar `set_with_hypothesis` bindings defined in earlier sorries were not found when processing later subgoals, resulting in warnings and fallback to `Prop` type.