### PR TITLE
Fix trailing newline handling to prevent Kimina server hangs

### DIFF
--- a/goedels_poetry/agents/proof_checker_agent.py
+++ b/goedels_poetry/agents/proof_checker_agent.py
@@ -171,8 +171,12 @@ def check_complete_proof(complete_proof: str, server_url: str, server_max_retrie
     # Create a client to access the Kimina Server
     kimina_client = KiminaClient(api_url=server_url, http_timeout=36000, n_retries=server_max_retries)
 
+    # Ensure trailing newline to prevent Kimina server hangs
+    # This follows POSIX standard that text files should end with a newline
+    normalized_proof = complete_proof if complete_proof.endswith("\n") else complete_proof + "\n"
+
     # The complete_proof is already a valid Lean file, so we can check it directly
-    check_response = kimina_client.check(complete_proof, timeout=36000)
+    check_response = kimina_client.check(normalized_proof, timeout=36000)
 
     # Parse check_response
     parsed_response = parse_kimina_check_response(check_response)
@@ -182,6 +186,7 @@ def check_complete_proof(complete_proof: str, server_url: str, server_max_retrie
 
     # Extract the result
     is_valid = parsed_response["complete"]
-    error_msg = get_error_str(complete_proof, parsed_response.get("errors", []), False) if not is_valid else ""
+    # Use normalized_proof (with trailing newline) for consistency with what was sent to Kimina
+    error_msg = get_error_str(normalized_proof, parsed_response.get("errors", []), False) if not is_valid else ""
 
     return is_valid, error_msg

--- a/goedels_poetry/agents/util/common.py
+++ b/goedels_poetry/agents/util/common.py
@@ -391,11 +391,18 @@ def combine_preamble_and_body(preamble: str, body: str) -> str:
     normalized_body = body.strip()
 
     if not normalized_preamble:
-        return normalized_body
-    if not normalized_body:
-        return normalized_preamble
+        result = normalized_body
+    elif not normalized_body:
+        result = normalized_preamble
+    else:
+        result = f"{normalized_preamble}\n\n{normalized_body}"
 
-    return f"{normalized_preamble}\n\n{normalized_body}"
+    # Ensure trailing newline to prevent Kimina server hangs
+    # This follows POSIX standard that text files should end with a newline
+    if result and not result.endswith("\n"):
+        result += "\n"
+
+    return result
 
 
 def strip_known_preamble(code: str, expected_preamble: str) -> tuple[str, bool]:
@@ -561,7 +568,7 @@ def get_error_str(code: str, errors: list[dict], error_thres: bool) -> str:  # n
         A string summarizing the errors in a format expected by Goedel-Prover-V2.
     """
     err_str = ""
-    code_lines = code.split("\n")
+    code_lines = code.splitlines(keepends=False)
     if not code_lines:
         code_lines = [""]
 


### PR DESCRIPTION
When LLM responses are truncated due to token limits, extracted Lean 4 code may not end with a trailing newline. This causes the Kimina Lean server to hang when processing such code, as the server's REPL expects complete lines terminated by newline characters (following POSIX standard).

Changes:
- Modified get_error_str() to use splitlines(keepends=False) instead of split("\n") for more robust line handling. This correctly handles trailing newlines without creating extra empty array elements and supports various line ending types (\n, \r\n, \r).

- Modified combine_preamble_and_body() to ensure the returned code always ends with a trailing newline. This centralizes the fix and ensures all code paths that send code to the Kimina server (via combine_preamble_and_body) are protected.

- Modified check_complete_proof() to ensure the complete_proof parameter has a trailing newline before sending to Kimina. This function receives pre-assembled proof strings that bypass combine_preamble_and_body(), so it needs explicit handling.

- Added 18 comprehensive tests covering:
  - get_error_str() with/without trailing newlines
  - get_error_str() with errors on last line
  - get_error_str() with Windows and old Mac line endings
  - get_error_str() with multiline errors ending at last line
  - combine_preamble_and_body() trailing newline behavior
  - Edge cases (empty preamble/body, whitespace handling)

This fix prevents server hangs while maintaining consistency between the code sent to Kimina and the code passed to get_error_str() for error reporting, ensuring accurate line number mapping in error messages.