### PR TITLE
Add pass and attempt tracking to LLM debug logging

### DIFF
--- a/goedels_poetry/agents/formalizer_agent.py
+++ b/goedels_poetry/agents/formalizer_agent.py
@@ -96,13 +96,22 @@ def _formalizer(llm: BaseChatModel, state: InformalTheoremState) -> InformalTheo
     )
 
     # Log debug prompt
-    log_llm_prompt("FORMALIZER_AGENT", prompt, "goedel-formalizer-v2")
+    log_llm_prompt(
+        "FORMALIZER_AGENT",
+        prompt,
+        "goedel-formalizer-v2",
+        attempt_num=state["formalization_attempts"],
+    )
 
     # Formalize informal statement
     response_content = llm.invoke(prompt).content
 
     # Log debug response
-    log_llm_response("FORMALIZER_AGENT_LLM", str(response_content))
+    log_llm_response(
+        "FORMALIZER_AGENT_LLM",
+        str(response_content),
+        attempt_num=state["formalization_attempts"],
+    )
 
     # Parse formalizer response
     try:

--- a/goedels_poetry/agents/informal_theorem_semantics_agent.py
+++ b/goedels_poetry/agents/informal_theorem_semantics_agent.py
@@ -96,13 +96,22 @@ def _check_semantics(llm: BaseChatModel, state: InformalTheoremState) -> Informa
     )
 
     # Log debug prompt
-    log_llm_prompt("SEMANTICS_AGENT", prompt, "goedel-semiotician-v2")
+    log_llm_prompt(
+        "SEMANTICS_AGENT",
+        prompt,
+        "goedel-semiotician-v2",
+        attempt_num=state["formalization_attempts"],
+    )
 
     # Determine if the semantics of the informal and formal theorems are the same
     response_content = llm.invoke(prompt).content
 
     # Log debug response
-    log_llm_response("SEMANTICS_AGENT_LLM", str(response_content))
+    log_llm_response(
+        "SEMANTICS_AGENT_LLM",
+        str(response_content),
+        attempt_num=state["formalization_attempts"],
+    )
 
     # Parse semantics checker response
     try:

--- a/goedels_poetry/agents/proof_corrector_agent.py
+++ b/goedels_poetry/agents/proof_corrector_agent.py
@@ -93,7 +93,13 @@ def _corrector(state: FormalTheoremProofState) -> FormalTheoremProofStates:
     )
 
     # Log debug prompt
-    log_llm_prompt("PROOF_CORRECTOR_AGENT", prompt, "goedel-prover-v2-subsequent")
+    log_llm_prompt(
+        "PROOF_CORRECTOR_AGENT",
+        prompt,
+        "goedel-prover-v2-subsequent",
+        attempt_num=state["self_correction_attempts"],
+        pass_num=state["pass_attempts"],
+    )
 
     # Add correction request to the state's proof_history
     state["proof_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/proof_sketcher_agent.py
+++ b/goedels_poetry/agents/proof_sketcher_agent.py
@@ -163,7 +163,12 @@ def _proof_sketcher(llm: BaseChatModel, state: DecomposedFormalTheoremState) -> 
         )
 
         # Log debug prompt
-        log_llm_prompt("PROOF_SKETCHER_AGENT", prompt, "decomposer-initial")
+        log_llm_prompt(
+            "PROOF_SKETCHER_AGENT",
+            prompt,
+            "decomposer-initial",
+            attempt_num=state["self_correction_attempts"],
+        )
 
         # Put the prompt in the final message
         state["decomposition_history"] += [HumanMessage(content=prompt)]
@@ -175,7 +180,11 @@ def _proof_sketcher(llm: BaseChatModel, state: DecomposedFormalTheoremState) -> 
     normalized_content = _extract_responses_api_content(response_content)
 
     # Log debug response
-    log_llm_response("DECOMPOSER_AGENT_LLM", normalized_content)
+    log_llm_response(
+        "DECOMPOSER_AGENT_LLM",
+        normalized_content,
+        attempt_num=state["self_correction_attempts"],
+    )
 
     # Parse sketcher response
     try:

--- a/goedels_poetry/agents/prover_agent.py
+++ b/goedels_poetry/agents/prover_agent.py
@@ -115,7 +115,13 @@ def _prover(llm: BaseChatModel, state: FormalTheoremProofState) -> FormalTheorem
         prompt = load_prompt("goedel-prover-v2-initial", formal_statement=formal_statement_with_imports)
 
         # Log debug prompt
-        log_llm_prompt("PROVER_AGENT", prompt, "goedel-prover-v2-initial")
+        log_llm_prompt(
+            "PROVER_AGENT",
+            prompt,
+            "goedel-prover-v2-initial",
+            attempt_num=state["self_correction_attempts"],
+            pass_num=state["pass_attempts"],
+        )
 
         # Put the prompt in the final message
         state["proof_history"] += [HumanMessage(content=prompt)]
@@ -124,7 +130,12 @@ def _prover(llm: BaseChatModel, state: FormalTheoremProofState) -> FormalTheorem
     response_content = llm.invoke(state["proof_history"]).content
 
     # Log debug response
-    log_llm_response("PROVER_AGENT_LLM", str(response_content))
+    log_llm_response(
+        "PROVER_AGENT_LLM",
+        str(response_content),
+        attempt_num=state["self_correction_attempts"],
+        pass_num=state["pass_attempts"],
+    )
 
     # Parse prover response
     try:

--- a/goedels_poetry/agents/search_query_agent.py
+++ b/goedels_poetry/agents/search_query_agent.py
@@ -146,11 +146,21 @@ def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremSt
         # Use backtrack prompt - the full history is already in decomposition_history
         prompt = load_prompt("search-query-backtrack", formal_theorem=formal_theorem_with_imports)
         # Log debug prompt
-        log_llm_prompt("SEARCH_QUERY_AGENT", prompt, "search-query-backtrack")
+        log_llm_prompt(
+            "SEARCH_QUERY_AGENT",
+            prompt,
+            "search-query-backtrack",
+            attempt_num=state["self_correction_attempts"],
+        )
     else:
         prompt = load_prompt("search-query-initial", formal_theorem=formal_theorem_with_imports)
         # Log debug prompt
-        log_llm_prompt("SEARCH_QUERY_AGENT", prompt, "search-query-initial")
+        log_llm_prompt(
+            "SEARCH_QUERY_AGENT",
+            prompt,
+            "search-query-initial",
+            attempt_num=state["self_correction_attempts"],
+        )
 
     # Add the prompt to decomposition_history
     state["decomposition_history"] += [HumanMessage(content=prompt)]
@@ -159,7 +169,11 @@ def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremSt
     response_content = llm.invoke(state["decomposition_history"]).content
 
     # Log debug response
-    log_llm_response("SEARCH_QUERY_AGENT_LLM", str(response_content))
+    log_llm_response(
+        "SEARCH_QUERY_AGENT_LLM",
+        str(response_content),
+        attempt_num=state["self_correction_attempts"],
+    )
 
     # Parse search query response
     search_queries = _parse_search_queries_response(str(response_content))

--- a/goedels_poetry/agents/sketch_backtrack_agent.py
+++ b/goedels_poetry/agents/sketch_backtrack_agent.py
@@ -95,7 +95,12 @@ def _backtrack(state: DecomposedFormalTheoremState) -> DecomposedFormalTheoremSt
     )
 
     # Log debug prompt
-    log_llm_prompt("SKETCH_BACKTRACK_AGENT", prompt, "decomposer-backtrack")
+    log_llm_prompt(
+        "SKETCH_BACKTRACK_AGENT",
+        prompt,
+        "decomposer-backtrack",
+        attempt_num=state["self_correction_attempts"],
+    )
 
     # Add backtrack request to the state's decomposition_history
     state["decomposition_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/sketch_corrector_agent.py
+++ b/goedels_poetry/agents/sketch_corrector_agent.py
@@ -94,7 +94,12 @@ def _corrector(state: DecomposedFormalTheoremState) -> DecomposedFormalTheoremSt
     )
 
     # Log debug prompt
-    log_llm_prompt("SKETCH_CORRECTOR_AGENT", prompt, "decomposer-subsequent")
+    log_llm_prompt(
+        "SKETCH_CORRECTOR_AGENT",
+        prompt,
+        "decomposer-subsequent",
+        attempt_num=state["self_correction_attempts"],
+    )
 
     # Add correction request to the state's decomposition_history
     state["decomposition_history"] += [HumanMessage(content=prompt)]

--- a/goedels_poetry/agents/util/debug.py
+++ b/goedels_poetry/agents/util/debug.py
@@ -41,7 +41,13 @@ def is_debug_enabled() -> bool:
     return _DEBUG_ENABLED
 
 
-def log_llm_prompt(agent_name: str, prompt: str, prompt_name: str | None = None) -> None:
+def log_llm_prompt(
+    agent_name: str,
+    prompt: str,
+    prompt_name: str | None = None,
+    attempt_num: int | None = None,
+    pass_num: int | None = None,
+) -> None:
     """
     Log an LLM prompt if debug mode is enabled.
 
@@ -53,6 +59,10 @@ def log_llm_prompt(agent_name: str, prompt: str, prompt_name: str | None = None)
         The prompt content to be sent to the LLM
     prompt_name : str, optional
         The name of the prompt template (e.g., "goedel-formalizer-v2"), by default None
+    attempt_num : int, optional
+        The attempt number (0-based), by default None
+    pass_num : int, optional
+        The pass number (0-based), by default None
     """
     if not _DEBUG_ENABLED:
         return
@@ -63,6 +73,19 @@ def log_llm_prompt(agent_name: str, prompt: str, prompt_name: str | None = None)
         title_parts.append(f"prompt: {prompt_name}")
     else:
         title_parts.append("prompt")
+
+    # Add pass/attempt info if provided
+    pass_attempt_parts = []
+    if pass_num is not None and attempt_num is not None:
+        pass_attempt_parts.append(f"pass {pass_num}, attempt {attempt_num}")
+    elif attempt_num is not None:
+        pass_attempt_parts.append(f"attempt {attempt_num}")
+    elif pass_num is not None:
+        pass_attempt_parts.append(f"pass {pass_num}")
+
+    if pass_attempt_parts:
+        title_parts.append(", ".join(pass_attempt_parts))
+
     title_parts.append(f"[dim]{timestamp}[/dim]")
     title = " - ".join(title_parts)
 
@@ -76,7 +99,13 @@ def log_llm_prompt(agent_name: str, prompt: str, prompt_name: str | None = None)
         _debug_console.print(Panel(prompt, title=title, border_style="yellow"))
 
 
-def log_llm_response(agent_name: str, response: str, response_type: str = "response") -> None:
+def log_llm_response(
+    agent_name: str,
+    response: str,
+    response_type: str = "response",
+    attempt_num: int | None = None,
+    pass_num: int | None = None,
+) -> None:
     """
     Log an LLM response if debug mode is enabled.
 
@@ -88,12 +117,32 @@ def log_llm_response(agent_name: str, response: str, response_type: str = "respo
         The response content from the LLM
     response_type : str, optional
         The type of response (e.g., "response", "parsed"), by default "response"
+    attempt_num : int, optional
+        The attempt number (0-based), by default None
+    pass_num : int, optional
+        The pass number (0-based), by default None
     """
     if not _DEBUG_ENABLED:
         return
 
     timestamp = _get_timestamp()
-    title = f"[bold cyan]{agent_name}[/bold cyan] - {response_type} - [dim]{timestamp}[/dim]"
+    title_parts = [f"[bold cyan]{agent_name}[/bold cyan]"]
+    title_parts.append(response_type)
+
+    # Add pass/attempt info if provided
+    pass_attempt_parts = []
+    if pass_num is not None and attempt_num is not None:
+        pass_attempt_parts.append(f"pass {pass_num}, attempt {attempt_num}")
+    elif attempt_num is not None:
+        pass_attempt_parts.append(f"attempt {attempt_num}")
+    elif pass_num is not None:
+        pass_attempt_parts.append(f"pass {pass_num}")
+
+    if pass_attempt_parts:
+        title_parts.append(", ".join(pass_attempt_parts))
+
+    title_parts.append(f"[dim]{timestamp}[/dim]")
+    title = " - ".join(title_parts)
 
     # Try to detect if response is Lean code
     if "```lean" in response or "theorem" in response or "lemma" in response:


### PR DESCRIPTION
Extend log_llm_prompt() and log_llm_response() to display pass and attempt numbers in debug log titles, providing better visibility into the retry and self-correction loops during proof generation.

Changes:
- Add optional attempt_num and pass_num parameters to log_llm_prompt() and log_llm_response() functions
- Update title formatting to include "pass N, attempt M" information before timestamps (0-based numbering)
- Update all agent call sites to extract and pass relevant state values:
  * InformalTheoremState: formalization_attempts (attempt only)
  * FormalTheoremProofState: pass_attempts and self_correction_attempts
  * DecomposedFormalTheoremState: self_correction_attempts (attempt only)

The pass number is only shown for FormalTheoremProofState (where pass_attempts can be > 0), while attempt numbers are shown for all state types that track attempts. This helps debug retry loops and self-correction cycles by making it clear which iteration of each loop is being logged.

All changes are backward compatible - the new parameters are optional and default to None, so existing code continues to work without modification.