### PR TITLE
Update decomposer agent model and add reasoning parameter

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -46,7 +46,7 @@ num_ctx = 262144
 max_remote_retries = 5
 
 [DECOMPOSER_AGENT_LLM]
-model = gpt-5.2-pro-2025-12-11
+model = gpt-5.2-2025-12-11
 provider = openai
 url = https://api.openai.com/v1
 max_tokens = 50000
@@ -218,7 +218,7 @@ Ensure your LM Studio server is running with the OpenAI-compatible server enable
 The decomposer agent can use any supported provider (Ollama, vLLM, LM Studio, or OpenAI) for proof sketching. By default, it uses OpenAI. Configuration parameters:
 
 - **`provider`**: The provider type - `"ollama"`, `"vllm"`, `"lmstudio"`, or `"openai"` (default: `"openai"`)
-- **`model`**: The model used for proof sketching (default: `gpt-5.2-pro-2025-12-11` for OpenAI)
+- **`model`**: The model used for proof sketching (default: `gpt-5.2-2025-12-11` for OpenAI)
 - **`url`**: The base URL for the API endpoint (default: `https://api.openai.com/v1` for OpenAI, provider-specific defaults for others)
 - **`max_tokens`**: Maximum tokens in generated response (default: `50000`). Note: `max_completion_tokens` is also supported for backward compatibility but `max_tokens` is preferred.
 - **`max_remote_retries`**: Maximum remote API retry attempts for network/API errors (default: `5`)

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ num_ctx = 262144
 max_remote_retries = 5
 
 [DECOMPOSER_AGENT_LLM]
-model = gpt-5.2-pro-2025-12-11
+model = gpt-5.2-2025-12-11
 provider = openai
 url = https://api.openai.com/v1
 max_tokens = 50000
@@ -691,7 +691,7 @@ package_filters = Mathlib,Batteries,Std,Init,Lean
 
 **Decomposer Agent**:
 - `provider`: The provider type - `"ollama"`, `"vllm"`, `"lmstudio"`, or `"openai"` (default: `"openai"`)
-- `model`: The model used for proof sketching (default: `gpt-5.2-pro-2025-12-11` for OpenAI)
+- `model`: The model used for proof sketching (default: `gpt-5.2-2025-12-11` for OpenAI)
 - `url`: The base URL for the API endpoint (default: `https://api.openai.com/v1` for OpenAI)
 - `max_tokens`: Maximum tokens in generated response (preferred over `max_completion_tokens`)
 - `max_remote_retries`: Maximum remote API retry attempts for network/API errors

--- a/goedels_poetry/config/llm.py
+++ b/goedels_poetry/config/llm.py
@@ -211,6 +211,7 @@ def _create_llm_safe(section: str, **kwargs):  # type: ignore[no-untyped-def]
     # For DECOMPOSER_AGENT_LLM with OpenAI, enable Responses API
     if section == "DECOMPOSER_AGENT_LLM" and provider == "openai":
         chat_openai_kwargs["use_responses_api"] = True
+        chat_openai_kwargs["reasoning"] = {"effort": "high"}
 
     # Add extra_body if not empty (now allowed for OpenAI when using Responses API)
     if extra_body:

--- a/goedels_poetry/data/config.ini
+++ b/goedels_poetry/data/config.ini
@@ -71,7 +71,7 @@ max_remote_retries = 5
 # ttl = 300
 
 [DECOMPOSER_AGENT_LLM]
-model = gpt-5.2-pro-2025-12-11
+model = gpt-5.2-2025-12-11
 # provider can be: ollama, vllm, lmstudio, or openai
 provider = openai
 # url is optional when provider=openai (defaults to https://api.openai.com/v1)


### PR DESCRIPTION
- Change default decomposer agent model from `gpt-5.2-pro-2025-12-11` to `gpt-5.2-2025-12-11` in configuration files and documentation
- Add `reasoning={"effort": "high"}` parameter to ChatOpenAI constructor for DECOMPOSER_AGENT_LLM when using OpenAI provider to enable high-effort reasoning

Changes:
- Updated `goedels_poetry/data/config.ini` with new model name
- Updated `README.md` and `CONFIGURATION.md` documentation with new model name (2 occurrences each)
- Added reasoning parameter in `goedels_poetry/config/llm.py` for decomposer agent with OpenAI provider
- Preserved historical reference in `CHANGELOG.md` as intended