### PR TITLE
Handle implicit/instance binders and pi/exists fallback

### DIFF
--- a/tests/test_binder_extraction_extended.py
+++ b/tests/test_binder_extraction_extended.py
@@ -1,0 +1,201 @@
+from __future__ import annotations
+
+from goedels_poetry.parsers.ast import AST
+
+
+def _implicit_instance_strict_theorem_ast() -> dict:
+    # theorem foo {alpha : Type} ⦃beta : Type⦄ [inst : Group alpha] (x : alpha) : True := by
+    #   have hgoal : True := by sorry
+    #   sorry
+    implicit_binder = {
+        "kind": "Lean.Parser.Term.implicitBinder",
+        "args": [
+            {"val": "{", "info": {"leading": " ", "trailing": ""}},
+            {"kind": "Lean.binderIdent", "args": [{"val": "alpha", "info": {"leading": "", "trailing": ""}}]},
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Type", "info": {"leading": "", "trailing": ""}},
+            {"val": "}", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    strict_implicit_binder = {
+        "kind": "Lean.Parser.Term.strictImplicitBinder",
+        "args": [
+            {"val": "⦃", "info": {"leading": " ", "trailing": ""}},
+            {"kind": "Lean.binderIdent", "args": [{"val": "beta", "info": {"leading": "", "trailing": ""}}]},
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Type", "info": {"leading": "", "trailing": ""}},
+            {"val": "⦄", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    inst_binder = {
+        "kind": "Lean.Parser.Term.instBinder",
+        "args": [
+            {"val": "[", "info": {"leading": " ", "trailing": ""}},
+            {"kind": "Lean.binderIdent", "args": [{"val": "inst", "info": {"leading": "", "trailing": ""}}]},
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Group alpha", "info": {"leading": "", "trailing": ""}},
+            {"val": "]", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    explicit_binder = {
+        "kind": "Lean.Parser.Term.explicitBinder",
+        "args": [
+            {"val": "(", "info": {"leading": " ", "trailing": ""}},
+            {"kind": "Lean.binderIdent", "args": [{"val": "x", "info": {"leading": "", "trailing": ""}}]},
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "alpha", "info": {"leading": "", "trailing": ""}},
+            {"val": ")", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    bracketed = {
+        "kind": "Lean.Parser.Term.bracketedBinderList",
+        "args": [implicit_binder, strict_implicit_binder, inst_binder, explicit_binder],
+    }
+    have_goal = {
+        "kind": "Lean.Parser.Tactic.tacticHave_",
+        "args": [
+            {"val": "have", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.haveDecl",
+                "args": [
+                    {
+                        "kind": "Lean.Parser.Term.haveIdDecl",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Term.haveId",
+                                "args": [{"val": "hgoal", "info": {"leading": "", "trailing": " "}}],
+                            }
+                        ],
+                    },
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "True", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": " "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticSorry",
+                                "args": [{"val": "sorry", "info": {"leading": "", "trailing": ""}}],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    theorem = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "foo", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "True", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {"kind": "Lean.Parser.Tactic.tacticSeq", "args": [have_goal]},
+                ],
+            },
+        ],
+    }
+    # Insert binder list into a declSig-like position to exercise the extractor's fast path.
+    theorem["args"].insert(
+        2,
+        {"kind": "Lean.Parser.Command.declSig", "args": [bracketed]},
+    )
+    return theorem
+
+
+def _fallback_relevance_ast() -> tuple[dict, list[dict]]:
+    # theorem bar : ∀ n : Int, True := by have hgoal : True := by sorry
+    # goal context includes n and a spurious junk; only n should appear.
+    have_goal = {
+        "kind": "Lean.Parser.Tactic.tacticHave_",
+        "args": [
+            {"val": "have", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.haveDecl",
+                "args": [
+                    {
+                        "kind": "Lean.Parser.Term.haveIdDecl",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Term.haveId",
+                                "args": [{"val": "hgoal", "info": {"leading": "", "trailing": " "}}],
+                            }
+                        ],
+                    },
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "True", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": " "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticSorry",
+                                "args": [{"val": "sorry", "info": {"leading": "", "trailing": ""}}],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    theorem = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "bar", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "True", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {"kind": "Lean.Parser.Tactic.tacticSeq", "args": [have_goal]},
+                ],
+            },
+        ],
+    }
+    sorries = [{"goal": "n : Int\njunk : False\n⊢ True"}]
+    return theorem, sorries
+
+
+def test_implicit_instance_and_strict_binders_are_extracted() -> None:
+    ast = AST(_implicit_instance_strict_theorem_ast(), sorries=[])
+
+    code = ast.get_named_subgoal_code("hgoal")
+    assert "{alpha : Type}" in code  # implicit
+    assert "⦃beta : Type⦄" in code  # strict implicit
+    assert "[inst : Group alpha]" in code  # instance binder
+    assert "(x : alpha)" in code  # explicit remains
+
+
+def test_goal_context_fallback_filters_unreferenced_names() -> None:
+    theorem, sorries = _fallback_relevance_ast()
+    ast = AST(theorem, sorries=sorries)
+
+    code = ast.get_named_subgoal_code("hgoal")
+    assert "(n : Int)" in code
+    assert "junk" not in code

--- a/tests/test_binder_type_parse_fallback.py
+++ b/tests/test_binder_type_parse_fallback.py
@@ -1,0 +1,280 @@
+from __future__ import annotations
+
+from goedels_poetry.parsers.ast import AST
+
+
+def _arrow_only_theorem_ast() -> dict:
+    # theorem arrow_only : P → Q → R := by have hgoal : R := by sorry; sorry
+    arrow_type = {
+        "kind": "Lean.Parser.Term.arrow",
+        "args": [
+            {"val": "P", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.arrow",
+                "args": [
+                    {"val": "Q", "info": {"leading": "", "trailing": " "}},
+                    {"val": "R", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+        ],
+    }
+    have_goal = {
+        "kind": "Lean.Parser.Tactic.tacticHave_",
+        "args": [
+            {"val": "have", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.haveDecl",
+                "args": [
+                    {
+                        "kind": "Lean.Parser.Term.haveIdDecl",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Term.haveId",
+                                "args": [{"val": "hgoal", "info": {"leading": "", "trailing": " "}}],
+                            }
+                        ],
+                    },
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "R", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": " "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticSorry",
+                                "args": [{"val": "sorry", "info": {"leading": "", "trailing": ""}}],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    theorem = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "arrow_only", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            arrow_type,
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {"kind": "Lean.Parser.Tactic.tacticSeq", "args": [have_goal]},
+                ],
+            },
+        ],
+    }
+    return theorem
+
+
+def _exists_head_theorem_ast() -> dict:
+    # theorem ex_head : ∃ x : Nat, x > 0 := by have hgoal : True := by sorry; sorry
+    exists_type = {
+        "kind": "Lean.Parser.Term.exists",
+        "args": [
+            {"val": "∃", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.explicitBinder",
+                "args": [
+                    {"val": "(", "info": {"leading": " ", "trailing": ""}},
+                    {"kind": "Lean.binderIdent", "args": [{"val": "x", "info": {"leading": "", "trailing": ""}}]},
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "Nat", "info": {"leading": "", "trailing": ""}},
+                    {"val": ")", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            {"val": "x > 0", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    have_goal = {
+        "kind": "Lean.Parser.Tactic.tacticHave_",
+        "args": [
+            {"val": "have", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.haveDecl",
+                "args": [
+                    {
+                        "kind": "Lean.Parser.Term.haveIdDecl",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Term.haveId",
+                                "args": [{"val": "hgoal", "info": {"leading": "", "trailing": " "}}],
+                            }
+                        ],
+                    },
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "True", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": " "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticSorry",
+                                "args": [{"val": "sorry", "info": {"leading": "", "trailing": ""}}],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    theorem = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "ex_head", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            exists_type,
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {"kind": "Lean.Parser.Tactic.tacticSeq", "args": [have_goal]},
+                ],
+            },
+        ],
+    }
+    return theorem
+
+
+def _mixed_implicit_instance_pi_ast() -> dict:
+    # theorem mix {alpha} [Group alpha] (x : alpha) : True := by have hgoal : True := by sorry; sorry
+    implicit_binder = {
+        "kind": "Lean.Parser.Term.implicitBinder",
+        "args": [
+            {"val": "{", "info": {"leading": " ", "trailing": ""}},
+            {"kind": "Lean.binderIdent", "args": [{"val": "alpha", "info": {"leading": "", "trailing": ""}}]},
+            {"val": "}", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    inst_binder = {
+        "kind": "Lean.Parser.Term.instBinder",
+        "args": [
+            {"val": "[", "info": {"leading": " ", "trailing": ""}},
+            {"kind": "Lean.binderIdent", "args": [{"val": "hG", "info": {"leading": "", "trailing": ""}}]},
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "Group alpha", "info": {"leading": "", "trailing": ""}},
+            {"val": "]", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    explicit_binder = {
+        "kind": "Lean.Parser.Term.explicitBinder",
+        "args": [
+            {"val": "(", "info": {"leading": " ", "trailing": ""}},
+            {"kind": "Lean.binderIdent", "args": [{"val": "x", "info": {"leading": "", "trailing": ""}}]},
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "alpha", "info": {"leading": "", "trailing": ""}},
+            {"val": ")", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    pi_type = {
+        "kind": "Lean.Parser.Term.forall",
+        "args": [
+            {"kind": "Lean.Parser.Term.bracketedBinderList", "args": [implicit_binder, inst_binder, explicit_binder]},
+            {"val": "True", "info": {"leading": "", "trailing": " "}},
+        ],
+    }
+    have_goal = {
+        "kind": "Lean.Parser.Tactic.tacticHave_",
+        "args": [
+            {"val": "have", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.haveDecl",
+                "args": [
+                    {
+                        "kind": "Lean.Parser.Term.haveIdDecl",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Term.haveId",
+                                "args": [{"val": "hgoal", "info": {"leading": "", "trailing": " "}}],
+                            }
+                        ],
+                    },
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "True", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": " "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticSorry",
+                                "args": [{"val": "sorry", "info": {"leading": "", "trailing": ""}}],
+                            }
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+    theorem = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "mix", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            pi_type,
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {"kind": "Lean.Parser.Tactic.tacticSeq", "args": [have_goal]},
+                ],
+            },
+        ],
+    }
+    return theorem
+
+
+def test_type_parse_fallback_arrow_only_without_sorries() -> None:
+    ast = AST(_arrow_only_theorem_ast(), sorries=[])
+    code = ast.get_named_subgoal_code("hgoal")
+    # Should synthesize anonymous hypotheses for arrow domains.
+    assert "(h : P" in code or "(h1 : P" in code
+    assert "(h2 : Q" in code or "(h1 : Q" in code
+
+
+def test_type_parse_fallback_exists_head_without_sorries() -> None:
+    ast = AST(_exists_head_theorem_ast(), sorries=[])
+    code = ast.get_named_subgoal_code("hgoal")
+    # Should include an existential hypothesis binder.
+    assert "(hExists : ∃" in code or "∃ x : Nat" in code
+
+
+def test_type_parse_handles_mixed_implicit_and_instance() -> None:
+    ast = AST(_mixed_implicit_instance_pi_ast(), sorries=[])
+    code = ast.get_named_subgoal_code("hgoal")
+    assert "{alpha}" in code
+    assert "[hG : Group alpha]" in code or "[hG : Group alpha]" in code  # instance binder present
+    assert "(x : alpha)" in code

--- a/tests/test_kimina_ast_sorries.py
+++ b/tests/test_kimina_ast_sorries.py
@@ -149,6 +149,83 @@ class _DummyAstResponse:
         self.results = [_DummyAstResult()]
 
 
+def _quantified_theorem_with_subgoals() -> dict:
+    """
+    Theorem whose type uses only quantifiers (no explicit binder list) to force
+    binder reconstruction from the type/goal context.
+    """
+    haves = [
+        _named_have("hn_nonneg", "0 ≤ n"),
+        _named_have("hm_gt", "m > 1"),
+    ]
+    return {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "A_quant", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "∀ n : Int, n > 1 → True", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {"kind": "Lean.Parser.Tactic.tacticSeq", "args": haves},
+                ],
+            },
+        ],
+    }
+
+
+def _quantified_sorries() -> list[dict]:
+    return [
+        {"goal": "n : Int\nhn : n > 1\n⊢ 0 ≤ n"},
+        {"goal": "n : Int\nhn : n > 1\nhn_nonneg : 0 ≤ n\nm : Nat\n⊢ m > 1"},
+    ]
+
+
+def _existential_theorem_with_subgoals() -> dict:
+    """
+    Theorem whose type starts with an existential; we expect either an existential
+    hypothesis binder or a reconstructed witness binder when goal context supplies it.
+    """
+    haves = [
+        _named_have("hq_pos", "q > 5"),
+        _named_have("hq_use", "q ≥ 5"),
+    ]
+    return {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "A_exist", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "∃ q : Nat, q > 5 ∧ True", "info": {"leading": "", "trailing": " "}},
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": "", "trailing": "\n  "}},
+                    {"kind": "Lean.Parser.Tactic.tacticSeq", "args": haves},
+                ],
+            },
+        ],
+    }
+
+
+def _existential_sorries() -> list[dict]:
+    # Provide both an existence hypothesis and a concrete witness in goal context.
+    return [
+        {"goal": "hq : ∃ q : Nat, q > 5 ∧ True\nq : Nat\n⊢ q > 5"},
+        {"goal": "hq : ∃ q : Nat, q > 5 ∧ True\nq : Nat\nhq_pos : q > 5\n⊢ q ≥ 5"},
+    ]
+
+
 def test_parse_ast_code_response_threads_sorries(monkeypatch: pytest.MonkeyPatch) -> None:
     _install_kimina_stub(monkeypatch, _DummyKiminaClient)
     kimina_server = importlib.import_module("goedels_poetry.agents.util.kimina_server")
@@ -227,3 +304,174 @@ def test_proof_parser_passes_goal_context(monkeypatch: pytest.MonkeyPatch) -> No
 
     code_hn = result["outputs"][0]["ast"].get_named_subgoal_code("hn_nonneg")
     _assert_binders_present(code_hn)
+
+
+class _QuantifiedAstResult:
+    def __init__(self) -> None:
+        self.module = "dummy"
+        self.error = None
+        self.ast = _quantified_theorem_with_subgoals()
+        self.sorries = _quantified_sorries()
+
+
+class _QuantifiedAstResponse:
+    def __init__(self) -> None:
+        self.results = [_QuantifiedAstResult()]
+
+
+class _QuantifiedKiminaClient:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def ast_code(self, _code: str) -> _QuantifiedAstResponse:
+        return _QuantifiedAstResponse()
+
+
+def test_quantified_header_reconstructs_binders_from_sorries(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_kimina_stub(monkeypatch, _QuantifiedKiminaClient)
+    sketch_parser_agent = importlib.import_module("goedels_poetry.agents.sketch_parser_agent")
+
+    state = {
+        "parent": None,
+        "children": [],
+        "depth": 0,
+        "formal_theorem": "theorem A_quant : ∀ n : Int, n > 1 → True := by sorry",
+        "preamble": DEFAULT_IMPORTS,
+        "proof_sketch": "theorem A_quant : ∀ n : Int, n > 1 → True := by sorry",
+        "syntactic": True,
+        "errors": "",
+        "ast": None,
+        "self_correction_attempts": 0,
+        "decomposition_history": [],
+        "search_queries": None,
+        "search_results": None,
+        "hole_name": None,
+        "hole_start": None,
+        "hole_end": None,
+    }
+
+    result = sketch_parser_agent._parse_sketch("url", 0, 0, state)  # type: ignore[arg-type]
+    ast = result["outputs"][0]["ast"]
+    assert ast is not None
+
+    code_hn = ast.get_named_subgoal_code("hn_nonneg")
+    assert "(n : Int)" in code_hn
+    assert "(hn : n > 1)" in code_hn
+
+
+class _ExistentialAstResult:
+    def __init__(self) -> None:
+        self.module = "dummy"
+        self.error = None
+        self.ast = _existential_theorem_with_subgoals()
+        self.sorries = _existential_sorries()
+
+
+class _ExistentialAstResponse:
+    def __init__(self) -> None:
+        self.results = [_ExistentialAstResult()]
+
+
+class _ExistentialKiminaClient:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        pass
+
+    def ast_code(self, _code: str) -> _ExistentialAstResponse:
+        return _ExistentialAstResponse()
+
+
+def test_existential_header_preserves_goal_context_binders(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_kimina_stub(monkeypatch, _ExistentialKiminaClient)
+    sketch_parser_agent = importlib.import_module("goedels_poetry.agents.sketch_parser_agent")
+
+    state = {
+        "parent": None,
+        "children": [],
+        "depth": 0,
+        "formal_theorem": "theorem A_exist : ∃ q : Nat, q > 5 ∧ True := by sorry",
+        "preamble": DEFAULT_IMPORTS,
+        "proof_sketch": "theorem A_exist : ∃ q : Nat, q > 5 ∧ True := by sorry",
+        "syntactic": True,
+        "errors": "",
+        "ast": None,
+        "self_correction_attempts": 0,
+        "decomposition_history": [],
+        "search_queries": None,
+        "search_results": None,
+        "hole_name": None,
+        "hole_start": None,
+        "hole_end": None,
+    }
+
+    result = sketch_parser_agent._parse_sketch("url", 0, 0, state)  # type: ignore[arg-type]
+    ast = result["outputs"][0]["ast"]
+    assert ast is not None
+
+    code_hq_pos = ast.get_named_subgoal_code("hq_pos")
+    # We expect the existential hypothesis and witness binder to be present.
+    assert "(hq : ∃ q : Nat, q > 5 ∧ True)" in code_hq_pos
+    assert "(q : Nat)" in code_hq_pos
+
+
+def test_quantified_header_reconstructs_binders_proof_parser(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_kimina_stub(monkeypatch, _QuantifiedKiminaClient)
+    proof_parser_agent = importlib.import_module("goedels_poetry.agents.proof_parser_agent")
+
+    state = {
+        "parent": None,
+        "depth": 0,
+        "formal_theorem": "theorem A_quant : ∀ n : Int, n > 1 → True := by sorry",
+        "preamble": DEFAULT_IMPORTS,
+        "syntactic": True,
+        "formal_proof": "",
+        "proved": False,
+        "errors": "",
+        "ast": None,
+        "self_correction_attempts": 0,
+        "proof_history": [],
+        "pass_attempts": 0,
+        "hole_name": None,
+        "hole_start": None,
+        "hole_end": None,
+    }
+
+    result = proof_parser_agent._parse_proof("url", 0, 0, state)  # type: ignore[arg-type]
+    ast = result["outputs"][0]["ast"]
+    assert ast is not None
+
+    code_hn = ast.get_named_subgoal_code("hn_nonneg")
+    assert "(n : Int)" in code_hn
+    assert "(hn : n > 1)" in code_hn
+
+
+def test_existential_header_preserves_goal_context_binders_proof_parser(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _install_kimina_stub(monkeypatch, _ExistentialKiminaClient)
+    proof_parser_agent = importlib.import_module("goedels_poetry.agents.proof_parser_agent")
+
+    state = {
+        "parent": None,
+        "depth": 0,
+        "formal_theorem": "theorem A_exist : ∃ q : Nat, q > 5 ∧ True := by sorry",
+        "preamble": DEFAULT_IMPORTS,
+        "syntactic": True,
+        "formal_proof": "",
+        "proved": False,
+        "errors": "",
+        "ast": None,
+        "self_correction_attempts": 0,
+        "proof_history": [],
+        "pass_attempts": 0,
+        "hole_name": None,
+        "hole_start": None,
+        "hole_end": None,
+    }
+
+    result = proof_parser_agent._parse_proof("url", 0, 0, state)  # type: ignore[arg-type]
+    ast = result["outputs"][0]["ast"]
+    assert ast is not None
+
+    code_hq_pos = ast.get_named_subgoal_code("hq_pos")
+    assert "(hq : ∃ q : Nat, q > 5 ∧ True)" in code_hq_pos
+    assert "(q : Nat)" in code_hq_pos


### PR DESCRIPTION
- extract implicit, strict-implicit, and instance binders from theorem headers; add existential head hypothesis
- add type-parse fallback for Pi/arrow/∃ when sorries are absent, with relevance-filtered goal-context fallback
- tighten goal-context filtering and keep minimal params to avoid dropping binders; add tests for implicit/instance and type-parse fallback cases
- all checks: make check, make docs-test, make test