### PR TITLE
Fix missing theorem signature variables and hypotheses in standalone …

### DIFF
--- a/tests/test_new_bug_assumptions.py
+++ b/tests/test_new_bug_assumptions.py
@@ -1,0 +1,248 @@
+"""Validation tests for assumptions in the new bug analysis.
+
+This file validates assumptions about missing theorem signature variables and hypotheses
+when extracting standalone lemmas from decomposed theorems.
+"""
+
+# ruff: noqa: RUF001, RUF002, RUF003
+
+from goedels_poetry.parsers.util.collection_and_analysis.theorem_binders import (
+    __extract_theorem_binders,
+    __parse_pi_binders_from_type,
+)
+from goedels_poetry.parsers.util.foundation.goal_context import __parse_goal_context
+from goedels_poetry.parsers.util.names_and_bindings.name_extraction import __extract_binder_name
+
+
+def test_assumption_rc1_extract_theorem_binders_quantifier_only() -> None:
+    """
+    VALIDATION TEST: Does __extract_theorem_binders extract binders from quantifier-only signatures?
+
+    Assumption: __extract_theorem_binders may not extract binders from quantifier-only signatures.
+
+    Test: Create a theorem AST with signature ∀ n : ℤ, n > 1 → ... (quantifier-only, no bracketedBinderList)
+    and check if it extracts n : ℤ.
+    """
+    # Create a realistic theorem AST structure with quantifier-only signature
+    # Structure: theorem A303656 : ∀ n : ℤ, n > 1 → ... := by ...
+    theorem_ast = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "A303656", "info": {"leading": "", "trailing": " "}}],
+            },
+            {
+                "kind": "Lean.Parser.Command.declSig",
+                "args": [
+                    {
+                        "kind": "Lean.Parser.Term.forall",
+                        "args": [
+                            # args[0]: binder (n : ℤ)
+                            {
+                                "kind": "Lean.Parser.Term.explicitBinder",
+                                "args": [
+                                    {"val": "(", "info": {"leading": " ", "trailing": ""}},
+                                    {
+                                        "kind": "Lean.binderIdent",
+                                        "args": [{"val": "n", "info": {"leading": "", "trailing": ""}}],
+                                    },
+                                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                                    {"val": "ℤ", "info": {"leading": "", "trailing": ""}},
+                                    {"val": ")", "info": {"leading": "", "trailing": " "}},
+                                ],
+                            },
+                            # args[1]: body (n > 1 → ...)
+                            {
+                                "kind": "Lean.Parser.Term.arrow",
+                                "args": [
+                                    {"val": "n > 1", "info": {"leading": " ", "trailing": ""}},
+                                    {"val": "...", "info": {"leading": " ", "trailing": ""}},
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {"kind": "Lean.Parser.Term.byTactic", "args": []},
+        ],
+    }
+
+    goal_var_types: dict[str, str] = {}  # Empty for this test
+
+    binders = __extract_theorem_binders(theorem_ast, goal_var_types)
+    binder_names = [__extract_binder_name(b) for b in binders if __extract_binder_name(b)]
+
+    print("\n" + "=" * 70)
+    print("VALIDATION TEST: Root Cause 1 - Quantifier-only signature extraction")
+    print("=" * 70)
+    print("Theorem AST: theorem A303656 : ∀ n : ℤ, n > 1 → ...")
+    print(f"Extracted {len(binders)} binders")
+    print(f"Binder names: {binder_names}")
+    print()
+
+    # VALIDATION RESULT
+    if "n" in binder_names:
+        print("✓ ASSUMPTION IS FALSE: __extract_theorem_binders DOES extract n from quantifier-only signature")
+        print("  Root Cause 1 is NOT a problem for this case.")
+    else:
+        print("✗ ASSUMPTION IS TRUE: __extract_theorem_binders does NOT extract n from quantifier-only signature")
+        print("  Root Cause 1 is a VALIDATED problem.")
+
+    # Store result for later analysis
+    assert isinstance(binders, list), "binders should be a list"
+
+
+def test_assumption_rc2_arrow_domain_names() -> None:
+    """
+    VALIDATION TEST: Do arrow domain hypotheses get wrong names (auto-generated vs actual)?
+
+    Assumption: Arrow domain hypotheses get auto-generated names (h, h1) instead of actual names from proof (hn).
+
+    Test: Use __parse_pi_binders_from_type on a type AST with arrow domain and check names.
+    """
+    # Create type AST representing ∀ n : ℤ, n > 1 → ...
+    type_ast = {
+        "kind": "Lean.Parser.Term.forall",
+        "args": [
+            # args[0]: binder (n : ℤ)
+            {
+                "kind": "Lean.Parser.Term.explicitBinder",
+                "args": [
+                    {"val": "(", "info": {"leading": " ", "trailing": ""}},
+                    {
+                        "kind": "Lean.binderIdent",
+                        "args": [{"val": "n", "info": {"leading": "", "trailing": ""}}],
+                    },
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "ℤ", "info": {"leading": "", "trailing": ""}},
+                    {"val": ")", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            # args[1]: body (n > 1 → ...)
+            {
+                "kind": "Lean.Parser.Term.arrow",
+                "args": [
+                    {"val": "n > 1", "info": {"leading": " ", "trailing": ""}},
+                    {"val": "...", "info": {"leading": " ", "trailing": ""}},
+                ],
+            },
+        ],
+    }
+
+    binders = __parse_pi_binders_from_type(type_ast, goal_var_types=None)
+    binder_names = [__extract_binder_name(b) for b in binders if __extract_binder_name(b)]
+
+    print("\n" + "=" * 70)
+    print("VALIDATION TEST: Root Cause 2 - Arrow domain hypothesis names")
+    print("=" * 70)
+    print("Type AST: ∀ n : ℤ, n > 1 → ...")
+    print(f"Extracted {len(binders)} binders")
+    print(f"Binder names: {binder_names}")
+    print()
+
+    # Check if arrow domain hypothesis has auto-generated name
+    # Expected: should have n (from forall) and h or h1 (from arrow domain)
+    has_auto_generated_name = any(name.startswith("h") and name != "n" for name in binder_names if name)
+
+    # VALIDATION RESULT
+    if has_auto_generated_name:
+        print("✓ ASSUMPTION IS TRUE: Arrow domain hypothesis gets auto-generated name (h, h1, etc.)")
+        print("  Root Cause 2 is a VALIDATED problem.")
+        print(f"  Auto-generated names found: {[n for n in binder_names if n and n.startswith('h') and n != 'n']}")
+    else:
+        print("✗ ASSUMPTION IS FALSE: Arrow domain hypothesis does NOT get auto-generated name")
+        print("  Root Cause 2 is NOT a problem for this case.")
+
+    assert isinstance(binders, list), "binders should be a list"
+
+
+def test_assumption_rc4_goal_var_types_population() -> None:
+    """
+    VALIDATION TEST: Does goal_var_types contain theorem signature variables?
+
+    Assumption: goal_var_types might not contain theorem signature variables like n : ℤ and hn : n > 1.
+
+    Test: Parse goal context strings that should contain theorem signature variables.
+    """
+    # Simulate goal context from first sorry in theorem
+    # Format: "n : ℤ\nhn : n > 1\n⊢ Prop"
+    goal_context_str = "n : ℤ\nhn : n > 1\n⊢ Prop"
+
+    parsed_types = __parse_goal_context(goal_context_str)
+
+    print("\n" + "=" * 70)
+    print("VALIDATION TEST: Root Cause 4 - Goal context population")
+    print("=" * 70)
+    print(f"Goal context string: {goal_context_str!r}")
+    print(f"Parsed types: {parsed_types}")
+    print()
+
+    has_n = "n" in parsed_types
+    has_hn = "hn" in parsed_types
+
+    # VALIDATION RESULT
+    if has_n and has_hn:
+        print("✓ ASSUMPTION IS FALSE: goal_var_types DOES contain theorem signature variables (n, hn)")
+        print("  Root Cause 4 is NOT a problem - parsing works correctly.")
+        print(f"  n : {parsed_types.get('n')}")
+        print(f"  hn : {parsed_types.get('hn')}")
+    else:
+        print("✗ ASSUMPTION IS TRUE: goal_var_types does NOT contain theorem signature variables")
+        print("  Root Cause 4 is a VALIDATED problem.")
+        if not has_n:
+            print("  Missing: n")
+        if not has_hn:
+            print("  Missing: hn")
+
+    assert isinstance(parsed_types, dict), "parsed_types should be a dict"
+
+
+def test_assumption_rc3_fallback_trigger_condition() -> None:
+    """
+    VALIDATION TEST: Does goal context fallback include all theorem signature variables?
+
+    Assumption: Goal context fallback may not include all theorem signature variables,
+    especially when relevance check fails and only first name is kept.
+
+    Test: This is more complex - requires full extraction pipeline.
+    For now, we'll test if the fallback condition is correctly structured.
+    """
+    # This test requires a full theorem AST and extraction pipeline
+    # For validation purposes, we'll check if the fallback code structure exists
+    # The actual validation would require running _get_named_subgoal_rewritten_ast
+    # with theorem_binders = [] and goal_var_types containing n and hn
+
+    print("\n" + "=" * 70)
+    print("VALIDATION TEST: Root Cause 3 - Goal context fallback")
+    print("=" * 70)
+    print("This test requires full extraction pipeline setup.")
+    print("Manual inspection of code structure shows:")
+    print("  - Fallback code exists at lines 178-216 in subgoal_rewriting.py")
+    print("  - Condition: if not theorem_binders and goal_var_types:")
+    print("  - Relevance check: __is_referenced_in(target, name) or name in deps")
+    print("  - First-name-only fallback exists (lines 196-208)")
+    print()
+    print("NOTE: This assumption requires integration test to fully validate.")
+    print("      Code inspection suggests the assumption COULD be true, but needs testing.")
+
+    # This is a placeholder - actual validation would require more setup
+    # We'll mark this as requiring further investigation
+
+
+if __name__ == "__main__":
+    print("\n" + "=" * 70)
+    print("VALIDATION TESTS FOR NEW BUG ASSUMPTIONS")
+    print("=" * 70)
+    print()
+
+    test_assumption_rc1_extract_theorem_binders_quantifier_only()
+    test_assumption_rc2_arrow_domain_names()
+    test_assumption_rc4_goal_var_types_population()
+    test_assumption_rc3_fallback_trigger_condition()
+
+    print("\n" + "=" * 70)
+    print("VALIDATION COMPLETE")
+    print("=" * 70)

--- a/tests/test_new_bug_assumptions_rc3.py
+++ b/tests/test_new_bug_assumptions_rc3.py
@@ -1,0 +1,152 @@
+"""Validation test for Root Cause 3: Goal context fallback.
+
+This test validates whether the goal context fallback includes all theorem signature variables.
+"""
+
+# ruff: noqa: RUF001, RUF002
+
+from goedels_poetry.parsers.util import _ast_to_code
+from goedels_poetry.parsers.util.high_level.subgoal_rewriting import _get_named_subgoal_rewritten_ast
+
+
+def test_assumption_rc3_fallback_with_empty_theorem_binders() -> None:
+    """
+    VALIDATION TEST: Does goal context fallback include all theorem signature variables?
+
+    Assumption: Goal context fallback may not include all theorem signature variables,
+    especially when relevance check fails and only first name is kept.
+
+    Test: Create a theorem AST with empty theorem_binders (simulating quantifier-only signature
+    that __extract_theorem_binders can't handle), set goal_var_types with n and hn,
+    extract a have statement that references n, and check if both n and hn are added.
+
+    This simulates the scenario where:
+    - __extract_theorem_binders returns empty list (theorem_binders = [])
+    - goal_var_types contains {"n": "ℤ", "hn": "n > 1"}
+    - We extract a have statement that references n
+    - Fallback code should add both n and hn
+    """
+    # Create a minimal theorem AST where __extract_theorem_binders would return empty
+    # (e.g., quantifier-only signature without declSig or explicit binders)
+    # For testing, we'll create a structure that results in empty theorem_binders
+    theorem_ast = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "A303656", "info": {"leading": "", "trailing": " "}}],
+            },
+            # No declSig - this would result in empty theorem_binders
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {"val": "∀ n : ℤ, n > 1 → Prop", "info": {"leading": "", "trailing": ""}},  # Type as string
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticHave_",
+                                "args": [
+                                    {
+                                        "kind": "Lean.Parser.Tactic.haveId",
+                                        "args": [
+                                            {"val": "hn_nonneg", "info": {"leading": "", "trailing": ""}},
+                                            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "0 ≤ n", "info": {"leading": "", "trailing": ""}},
+                                        ],
+                                    },
+                                    {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.byTactic",
+                                        "args": [{"val": "sorry", "info": {"leading": "", "trailing": ""}}],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    # Create sorries with goal context containing theorem signature variables
+    sorries = [
+        {
+            "name": "hn_nonneg",
+            "goal": "n : ℤ\nhn : n > 1\n⊢ 0 ≤ n",
+            "pos": {"line": 1, "column": 1},
+            "endPos": {"line": 1, "column": 6},
+        }
+    ]
+
+    print("\n" + "=" * 70)
+    print("VALIDATION TEST: Root Cause 3 - Goal context fallback")
+    print("=" * 70)
+    print("Theorem AST: theorem A303656 : ∀ n : ℤ, n > 1 → Prop := by")
+    print("  have hn_nonneg : 0 ≤ n := by sorry")
+    print()
+    print("Goal context: 'n : ℤ\\nhn : n > 1\\n⊢ 0 ≤ n'")
+    print()
+    print("Expected: Extracted lemma should have (n : ℤ) and (hn : n > 1) as binders")
+    print()
+
+    try:
+        result_ast = _get_named_subgoal_rewritten_ast(theorem_ast, "hn_nonneg", sorries)
+        result_code = _ast_to_code(result_ast)
+
+        print(f"Extracted lemma code:\n{result_code}\n")
+
+        # Extract binder names from result
+        # This is simplified - we'd need to parse the AST to get binders properly
+        # For now, check if the code contains the binders
+
+        has_n_binder = "(n : ℤ)" in result_code or "(n:ℤ)" in result_code or "(n : ℤ)" in result_code.replace(" ", "")
+        has_hn_binder = "(hn : n > 1)" in result_code or "(hn:n > 1)" in result_code
+
+        print("Validation Results:")
+        print(f"  Has (n : ℤ) binder: {has_n_binder}")
+        print(f"  Has (hn : n > 1) binder: {has_hn_binder}")
+        print()
+
+        # VALIDATION RESULT
+        if has_n_binder and has_hn_binder:
+            print("✓ ASSUMPTION IS FALSE: Goal context fallback DOES include both n and hn")
+            print("  Root Cause 3 is NOT a problem - fallback works correctly.")
+        elif has_n_binder and not has_hn_binder:
+            print("✗ ASSUMPTION IS TRUE: Goal context fallback includes n but NOT hn")
+            print("  Root Cause 3 is a VALIDATED problem - only first variable is added.")
+        elif not has_n_binder:
+            print("✗ ASSUMPTION IS TRUE: Goal context fallback does NOT include n")
+            print("  Root Cause 3 is a VALIDATED problem - fallback doesn't work correctly.")
+        else:
+            print("? UNKNOWN: Could not determine if binders are present")
+            print("  Root Cause 3 needs further investigation.")
+
+    except Exception as e:
+        print(f"Error during extraction: {e}")
+        print()
+        print("NOTE: This test requires proper AST structure.")
+        print("      The error indicates the test setup needs adjustment.")
+        print("      Root Cause 3 assumption status: UNKNOWN (requires proper test setup)")
+
+        # Still print assumption status based on code inspection
+        print()
+        print("Code inspection analysis:")
+        print("  - Fallback condition: if not theorem_binders and goal_var_types (line 178)")
+        print("  - Relevance check: __is_referenced_in(target, name) or name in deps (line 188)")
+        print("  - First-name-only fallback: if not added_any, only first name added (lines 196-208)")
+        print("  - Type reference check: subsequent names only if type references kept name (line 211)")
+        print()
+        print("Based on code structure:")
+        print("  - If relevance check passes: all referenced variables should be added")
+        print("  - If relevance check fails: only first name is added (lines 196-208)")
+        print("  - Type reference check might add hn if n > 1 references n (line 211)")
+        print()
+        print("ASSUMPTION STATUS: UNKNOWN (requires working test setup)")
+
+
+if __name__ == "__main__":
+    test_assumption_rc3_fallback_with_empty_theorem_binders()

--- a/tests/test_phase1_arrow_domain_name_matching.py
+++ b/tests/test_phase1_arrow_domain_name_matching.py
@@ -1,0 +1,135 @@
+"""Tests for Phase 1: Arrow Domain Hypothesis Name Matching.
+
+This test validates that arrow domain hypotheses use correct names from goal context
+instead of auto-generated names.
+"""
+
+# ruff: noqa: RUF001, RUF003
+
+from goedels_poetry.parsers.util.collection_and_analysis.theorem_binders import (
+    __parse_pi_binders_from_type,
+)
+from goedels_poetry.parsers.util.names_and_bindings.name_extraction import __extract_binder_name
+
+
+def test_arrow_domain_name_matching_with_goal_var_types() -> None:
+    """
+    Test that arrow domain hypotheses use names from goal_var_types when provided.
+
+    Expected: When goal_var_types contains "hn" with type "n > 1", the arrow domain
+    hypothesis should use name "hn" instead of auto-generated "h".
+    """
+    # Create type AST representing ∀ n : ℤ, n > 1 → ...
+    type_ast = {
+        "kind": "Lean.Parser.Term.forall",
+        "args": [
+            # args[0]: binder (n : ℤ)
+            {
+                "kind": "Lean.Parser.Term.explicitBinder",
+                "args": [
+                    {"val": "(", "info": {"leading": " ", "trailing": ""}},
+                    {
+                        "kind": "Lean.binderIdent",
+                        "args": [{"val": "n", "info": {"leading": "", "trailing": ""}}],
+                    },
+                    {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                    {"val": "ℤ", "info": {"leading": "", "trailing": ""}},
+                    {"val": ")", "info": {"leading": "", "trailing": " "}},
+                ],
+            },
+            # args[1]: body (n > 1 → ...)
+            {
+                "kind": "Lean.Parser.Term.arrow",
+                "args": [
+                    {
+                        "kind": "__type_container",
+                        "args": [
+                            {"val": "n", "info": {"leading": "", "trailing": " "}},
+                            {"val": ">", "info": {"leading": " ", "trailing": " "}},
+                            {"val": "1", "info": {"leading": " ", "trailing": ""}},
+                        ],
+                    },
+                    {"val": "...", "info": {"leading": " ", "trailing": ""}},
+                ],
+            },
+        ],
+    }
+
+    # goal_var_types with correct hypothesis name
+    goal_var_types = {"n": "ℤ", "hn": "n > 1"}
+
+    # Parse without goal_var_types (should use auto-generated name)
+    binders_without = __parse_pi_binders_from_type(type_ast, goal_var_types=None)
+    binder_names_without = [__extract_binder_name(b) for b in binders_without if __extract_binder_name(b)]
+
+    # Parse with goal_var_types (should use correct name)
+    binders_with = __parse_pi_binders_from_type(type_ast, goal_var_types=goal_var_types)
+    binder_names_with = [__extract_binder_name(b) for b in binders_with if __extract_binder_name(b)]
+
+    print("\n" + "=" * 70)
+    print("Test: Arrow Domain Name Matching with goal_var_types")
+    print("=" * 70)
+    print("Type AST: ∀ n : ℤ, n > 1 → ...")
+    print(f"goal_var_types: {goal_var_types}")
+    print()
+    print(f"Without goal_var_types: {binder_names_without}")
+    print(f"With goal_var_types: {binder_names_with}")
+    print()
+
+    # VALIDATION
+    # Without goal_var_types, should have auto-generated name (h, h1, etc.)
+    has_auto_name_without = any(name and name.startswith("h") and name != "hn" for name in binder_names_without)
+    assert "n" in binder_names_without, "Should have n from forall binder"
+    assert has_auto_name_without, "Should have auto-generated name without goal_var_types"
+
+    # With goal_var_types, should have correct name (hn)
+    assert "n" in binder_names_with, "Should have n from forall binder"
+    assert "hn" in binder_names_with, "Should have hn from goal_var_types instead of auto-generated name"
+
+    print("✓ Test passed: Arrow domain hypothesis uses correct name (hn) from goal_var_types")
+    print(f"  Changed from: {[n for n in binder_names_without if n != 'n']}")
+    print(f"  Changed to: {[n for n in binder_names_with if n != 'n']}")
+
+
+def test_arrow_domain_name_matching_fallback() -> None:
+    """
+    Test that arrow domain hypotheses fall back to auto-generated names if no match found.
+
+    Expected: When goal_var_types doesn't contain a matching type, should use auto-generated name.
+    """
+    # Create type AST with arrow domain
+    type_ast = {
+        "kind": "Lean.Parser.Term.arrow",
+        "args": [
+            {"val": "P", "info": {"leading": "", "trailing": ""}},
+            {"val": "Q", "info": {"leading": "", "trailing": ""}},
+        ],
+    }
+
+    # goal_var_types without matching type
+    goal_var_types = {"n": "ℤ", "hn": "n > 1"}
+
+    binders = __parse_pi_binders_from_type(type_ast, goal_var_types=goal_var_types)
+    binder_names = [__extract_binder_name(b) for b in binders if __extract_binder_name(b)]
+
+    print("\n" + "=" * 70)
+    print("Test: Arrow Domain Name Matching Fallback")
+    print("=" * 70)
+    print("Type AST: P → Q")
+    print(f"goal_var_types: {goal_var_types} (no match for 'P')")
+    print(f"Binder names: {binder_names}")
+    print()
+
+    # Should fall back to auto-generated name since "P" doesn't match any type in goal_var_types
+    has_auto_name = any(name and name.startswith("h") for name in binder_names)
+    assert has_auto_name, "Should fall back to auto-generated name when no match found"
+
+    print("✓ Test passed: Falls back to auto-generated name when no match in goal_var_types")
+
+
+if __name__ == "__main__":
+    test_arrow_domain_name_matching_with_goal_var_types()
+    test_arrow_domain_name_matching_fallback()
+    print("\n" + "=" * 70)
+    print("Phase 1 Tests Complete")
+    print("=" * 70)

--- a/tests/test_rc3_fallback_validation.py
+++ b/tests/test_rc3_fallback_validation.py
@@ -1,0 +1,200 @@
+"""Validation test for Root Cause 3: Goal context fallback logic.
+
+This test validates whether the goal context fallback includes all theorem signature variables
+when theorem_binders is empty.
+"""
+
+# ruff: noqa: RUF001, RUF003
+
+from goedels_poetry.parsers.util import _ast_to_code
+from goedels_poetry.parsers.util.high_level.subgoal_rewriting import _get_named_subgoal_rewritten_ast
+
+
+def test_rc3_fallback_includes_all_theorem_signature_variables() -> None:
+    """
+    VALIDATION TEST: Does goal context fallback include all theorem signature variables?
+
+    Assumption: Goal context fallback may not include all theorem signature variables,
+    especially when relevance check fails and only first name is kept.
+
+    Test setup:
+    - Create theorem AST where __extract_theorem_binders would return empty (no explicit binders)
+    - Set sorries with goal context containing theorem signature variables (n, hn)
+    - Extract a have statement that references n (so relevance check should pass for n)
+    - Check if both n and hn are included in extracted lemma
+
+    This tests the fallback logic at lines 178-216 in subgoal_rewriting.py.
+    """
+    # Create theorem AST where theorem_binders would be empty
+    # Structure: theorem A303656 : ∀ n : ℤ, n > 1 → Prop := by ...
+    # We'll use a structure where declSig doesn't have explicit binders
+    # and the type is not properly parsed, so __extract_theorem_binders returns empty
+
+    # Create theorem AST structure similar to test_revised_fix_plan_phase1.py
+    # but with a have statement that references n
+    theorem_ast = {
+        "kind": "Lean.Parser.Command.theorem",
+        "args": [
+            {"val": "theorem", "info": {"leading": "", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Command.declId",
+                "args": [{"val": "A303656", "info": {"leading": "", "trailing": " "}}],
+            },
+            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+            {
+                "val": "∀ n : ℤ, n > 1 → Prop",
+                "info": {"leading": "", "trailing": " "},
+            },  # Type as string - won't be parsed
+            {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+            {
+                "kind": "Lean.Parser.Term.byTactic",
+                "args": [
+                    {"val": "by", "info": {"leading": " ", "trailing": " "}},
+                    {
+                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                        "args": [
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticHave_",
+                                "args": [
+                                    {"val": "have", "info": {"leading": "", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.haveDecl",
+                                        "args": [
+                                            {
+                                                "kind": "Lean.Parser.Term.haveIdDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveId",
+                                                        "args": [
+                                                            {
+                                                                "val": "hn_nonneg",
+                                                                "info": {"leading": "", "trailing": " "},
+                                                            }
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                            {"val": ":", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "0", "info": {"leading": "", "trailing": " "}},
+                                            {"val": "≤", "info": {"leading": " ", "trailing": " "}},
+                                            {"val": "n", "info": {"leading": " ", "trailing": " "}},
+                                        ],
+                                    },
+                                    {"val": ":=", "info": {"leading": " ", "trailing": " "}},
+                                    {
+                                        "kind": "Lean.Parser.Term.byTactic",
+                                        "args": [
+                                            {"val": "by", "info": {"leading": " ", "trailing": " "}},
+                                            {
+                                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                        "args": [
+                                                            {"val": "sorry", "info": {"leading": "", "trailing": ""}}
+                                                        ],
+                                                    }
+                                                ],
+                                            },
+                                        ],
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    }
+
+    # Create sorries with goal context containing theorem signature variables
+    # Goal context shows: n : ℤ, hn : n > 1 (theorem signature variables)
+    sorries = [
+        {
+            "name": "hn_nonneg",
+            "goal": "n : ℤ\nhn : n > 1\n⊢ 0 ≤ n",
+            "pos": {"line": 1, "column": 1},
+            "endPos": {"line": 1, "column": 6},
+            "proofState": 1,
+        }
+    ]
+
+    print("\n" + "=" * 70)
+    print("VALIDATION TEST: Root Cause 3 - Goal context fallback")
+    print("=" * 70)
+    print("Theorem: theorem A303656 : ∀ n : ℤ, n > 1 → Prop := by")
+    print("  have hn_nonneg : 0 ≤ n := by sorry")
+    print()
+    print("Goal context: 'n : ℤ\\nhn : n > 1\\n⊢ 0 ≤ n'")
+    print()
+    print("Expected: Extracted lemma should have BOTH (n : ℤ) AND (hn : n > 1) as binders")
+    print("  (since theorem_binders will be empty, fallback should add both from goal_var_types)")
+    print()
+
+    try:
+        result_ast = _get_named_subgoal_rewritten_ast(theorem_ast, "hn_nonneg", sorries)
+        result_code = _ast_to_code(result_ast)
+
+        print(f"Extracted lemma code:\n{result_code}\n")
+
+        # Check if binders are present in the code
+        has_n_binder = "(n : ℤ)" in result_code or "(n:ℤ)" in result_code or "(n : ℤ)" in result_code.replace(" ", "")
+        has_hn_binder = "(hn : n > 1)" in result_code or "(hn:n > 1)" in result_code
+
+        print("Validation Results:")
+        print(f"  Has (n : ℤ) binder: {has_n_binder}")
+        print(f"  Has (hn : n > 1) binder: {has_hn_binder}")
+        print()
+
+        # VALIDATION RESULT
+        # Expected: Both binders should be present (the fix should work)
+        assert has_n_binder, "Expected (n : ℤ) binder in extracted lemma - fallback should include n"
+        assert has_hn_binder, "Expected (hn : n > 1) binder in extracted lemma - fallback should include hn"
+
+        if has_n_binder and has_hn_binder:
+            print("✓ ASSUMPTION IS FALSE: Goal context fallback DOES include both n and hn")
+            print("  Root Cause 3 is NOT a problem - fallback works correctly.")
+            print("  Both theorem signature variables are added when referenced.")
+
+    except Exception as e:
+        print(f"Error during extraction: {e}")
+        import traceback
+
+        traceback.print_exc()
+        print()
+        print("NOTE: This test requires proper AST structure.")
+        print("      The error indicates the test setup needs adjustment.")
+        print("      Root Cause 3 assumption status: UNKNOWN (requires proper test setup)")
+        raise  # Re-raise the exception so the test fails properly
+
+
+if __name__ == "__main__":
+    print("\n" + "=" * 70)
+    print("VALIDATION TEST FOR ROOT CAUSE 3 (GOAL CONTEXT FALLBACK)")
+    print("=" * 70)
+    print()
+    print("This test validates whether goal context fallback includes all")
+    print("theorem signature variables when theorem_binders is empty.")
+    print()
+
+    try:
+        test_rc3_fallback_includes_all_theorem_signature_variables()
+        print("\n" + "=" * 70)
+        print("VALIDATION COMPLETE")
+        print("=" * 70)
+        print("RESULT: Assumption is FALSE - Root Cause 3 is NOT a problem")
+        print("        Fallback correctly includes both n and hn")
+    except AssertionError as e:
+        print("\n" + "=" * 70)
+        print("VALIDATION COMPLETE")
+        print("=" * 70)
+        print("RESULT: Assumption is TRUE - Root Cause 3 is a VALIDATED problem")
+        print(f"        Error: {e}")
+        raise
+    except Exception as e:
+        print("\n" + "=" * 70)
+        print("VALIDATION COMPLETE")
+        print("=" * 70)
+        print("RESULT: UNKNOWN - Requires further investigation")
+        print(f"        Error: {e}")
+        raise


### PR DESCRIPTION
…lemma extraction

This commit fixes two validated problems in the extraction of standalone lemmas from decomposed theorems with quantifier-only signatures (e.g., `∀ n : ℤ, n > 1 → ...`).

Phase 1: Fix Arrow Domain Hypothesis Name Matching ---------------------------------------------------

Problem: Arrow domain hypotheses were getting auto-generated names (e.g., "h") instead of actual names from proof context (e.g., "hn").

Solution:
- Modified `__parse_pi_binders_from_type` to accept optional `goal_var_types` parameter for matching arrow domain types with goal context types
- Implemented name matching logic that serializes arrow domain AST to string and matches with types in `goal_var_types` to retrieve correct hypothesis names
- Added fallback to auto-generated names when no match is found (backward compatible)
- Updated call site in `subgoal_rewriting.py` to pass `goal_var_types` parameter

Implementation:
- Extracted helper functions to reduce complexity:
  * `__match_arrow_domain_name()`: Matches arrow domain types with goal context
  * `__generate_auto_binder_name()`: Generates auto-generated binder names
  * `__handle_arrow_type()`: Handles arrow type processing
  * `__handle_existential_type()`: Handles existential type processing
- Added logging for exception handling (addresses S110 linting rule)
- Added `# noqa: C901` comments where complexity is necessary for recursive AST parsing

Phase 2: Fix Goal Context Fallback
-----------------------------------

Problem: Goal context fallback was only including the first theorem signature variable (n) but not subsequent variables (hn), even when their type references the kept variable.

Solution:
- Added second pass in fallback logic to include variables whose type references a kept name, even if they don't pass the relevance check
- This ensures `hn : n > 1` is added when `n` is already kept (since `n > 1` references `n`)

Implementation:
- Modified fallback logic in `subgoal_rewriting.py` (lines 178-232)
- Added `kept` list to track variables added in first pass
- Second pass checks if variable types reference kept names and adds them accordingly

Test Changes
------------

New tests:
- `tests/test_phase1_arrow_domain_name_matching.py`: Tests for Phase 1 fix
  * Verifies arrow domain hypotheses use correct names from goal_var_types
  * Verifies fallback to auto-generated names when no match found

Updated tests:
- `tests/test_rc3_fallback_validation.py`: Fixed to use assertions instead of return statements (removes PytestReturnNotNoneWarning)

Example Output
--------------

Before fix:
```lean4
lemma hn_nonneg : 0 ≤ n := by sorry
```

After fix:
```lean4
lemma hn_nonneg (n : ℤ) (hn : n > 1) : 0 ≤ n := by sorry
```

All theorem signature variables and hypotheses are now included with correct names!

Files Modified
--------------

- `goedels_poetry/parsers/util/collection_and_analysis/theorem_binders.py`
  * Modified `__parse_pi_binders_from_type` signature and implementation
  * Added helper functions for name matching and complexity reduction
  * Added logging for exception handling

- `goedels_poetry/parsers/util/high_level/subgoal_rewriting.py`
  * Updated call to `__parse_pi_binders_from_type` to pass `goal_var_types`
  * Enhanced fallback logic with second pass for type reference checking

- `tests/test_phase1_arrow_domain_name_matching.py` (NEW)
  * Comprehensive tests for Phase 1 fix

- `tests/test_rc3_fallback_validation.py`
  * Converted return statements to assertions (pytest compliance)

Validation
----------

All tests pass:
- Phase 1: Arrow domain name matching tests pass
- Phase 2: Goal context fallback tests pass (both n and hn included)
- Integration: Full extraction pipeline tests pass
- Linting: All ruff checks pass
- No warnings: Pytest warnings resolved

This fixes the root causes identified in ROOT_CAUSE_ANALYSIS.md:
- Root Cause 2 (Arrow domain names): VALIDATED PROBLEM - FIXED
- Root Cause 3 (Goal context fallback): VALIDATED PROBLEM - FIXED