### PR TITLE
fix: reconstruct from canonical sketch text

### DIFF
--- a/goedels_poetry/agents/util/debug.py
+++ b/goedels_poetry/agents/util/debug.py
@@ -204,6 +204,30 @@ def log_vectordb_response(operation: str, response: list[Any]) -> None:
     _debug_console.print(Panel(syntax, title=title, border_style="green"))
 
 
+def log_reconstruction_event(event: str, payload: dict[str, Any]) -> None:
+    """
+    Log a reconstruction event if debug mode is enabled.
+
+    Parameters
+    ----------
+    event : str
+        Short event name (e.g., "use_canonical_sketch", "hole_unresolved")
+    payload : dict[str, Any]
+        Event payload to display
+    """
+    if not _DEBUG_ENABLED:
+        return
+
+    timestamp = _get_timestamp()
+    title = f"[bold blue]RECONSTRUCTION[/bold blue] - {event} - [dim]{timestamp}[/dim]"
+
+    import json
+
+    formatted_payload = json.dumps(payload, indent=2, default=str)
+    syntax = Syntax(formatted_payload, "json", theme="monokai", line_numbers=False)
+    _debug_console.print(Panel(syntax, title=title, border_style="blue"))
+
+
 def log_debug_message(message: str, style: str = "yellow") -> None:
     """
     Log a general debug message if debug mode is enabled.

--- a/goedels_poetry/parsers/ast.py
+++ b/goedels_poetry/parsers/ast.py
@@ -173,6 +173,18 @@ class AST:
         """
         return self._body_start
 
+    def get_body_text(self) -> str | None:
+        """
+        Return the exact body text slice from the original source text, if available.
+
+        This preserves the exact character layout used by Kimina parsing, which is required
+        for stable offset-based reconstruction.
+        """
+        if self._source_text is None:
+            return None
+        start = max(0, int(self._body_start))
+        return self._source_text[start:]
+
     def set_source_text(self, source_text: str | None, *, body_start: int | None = None) -> None:
         """
         Set/replace the source text metadata for this AST.

--- a/tests/test_reconstruction_kimina_generated.py
+++ b/tests/test_reconstruction_kimina_generated.py
@@ -6,7 +6,7 @@ variations) so we can iterate on reconstruction correctness without proving real
 
 Configuration (env vars)
 ------------------------
-- RECONSTRUCTION_TEST_CASES: number of generated cases to run (default: 600). Set to 0 to skip.
+- RECONSTRUCTION_TEST_CASES: number of generated cases to run (default: 200). Set to 0 to skip.
 - RECONSTRUCTION_TEST_SEED: seed used to shuffle the deterministic corpus (default: 0).
 
 These tests match the conventions in `tests/test_kimina_agents.py`:
@@ -409,7 +409,7 @@ if IMPORTS_AVAILABLE:
         assert parsed_check["complete"] is True, parsed_check
 
     def _selected_cases() -> list[ReconCase]:
-        n = _env_int("RECONSTRUCTION_TEST_CASES", 600)
+        n = _env_int("RECONSTRUCTION_TEST_CASES", 200)
         seed = _env_int("RECONSTRUCTION_TEST_SEED", 0)
         if n <= 0:
             return []


### PR DESCRIPTION
Use the AST-derived body slice for reconstruction to keep sorry offsets aligned, and add debug-gated audit events for unresolved holes. Add a regression test for canonical sketch preference and reduce the Kimina-generated default test count to 200 for faster runs.