### PR TITLE
Fix multiline hypothesis parsing in unsolved goals

### DIFF
--- a/goedels_poetry/agents/util/kimina_server.py
+++ b/goedels_poetry/agents/util/kimina_server.py
@@ -4,6 +4,8 @@ from typing import Any, cast
 
 from kimina_client.models import AstModuleResponse, CheckResponse, CommandResponse, Message
 
+from goedels_poetry.parsers.util.hypothesis_extraction import extract_hypotheses_from_unsolved_goals_data
+
 
 def parse_kimina_check_response(check_response: CheckResponse) -> dict:
     """
@@ -88,7 +90,7 @@ def parse_kimina_ast_code_response(ast_code_response: AstModuleResponse) -> dict
     return parsed_response
 
 
-def extract_hypotheses_from_check_response(parsed_check_response: dict) -> list[str]:  # noqa: C901
+def extract_hypotheses_from_check_response(parsed_check_response: dict) -> list[str]:
     """
     Extract hypothesis strings from "unsolved goals" error messages in a parsed check response.
 
@@ -132,17 +134,7 @@ def extract_hypotheses_from_check_response(parsed_check_response: dict) -> list[
             continue
 
         found_unsolved_goals = True
-        lines = data.splitlines()
-
-        # Process lines after "unsolved goals" (first line)
-        for line in lines[1:]:
-            stripped = line.strip()
-            # Stop at the goal line (starts with ⊢ or \u22a2)
-            if stripped.startswith("⊢") or stripped.startswith("\u22a2"):
-                break
-            # Skip blank lines for robustness (kimina server shouldn't produce them, but be safe)
-            if stripped:
-                hypotheses.append(stripped)
+        hypotheses.extend(extract_hypotheses_from_unsolved_goals_data(data))
 
     if not found_unsolved_goals:
         raise ValueError('No error message contains "unsolved goals" in its data field')  # noqa: TRY003

--- a/goedels_poetry/parsers/util/hypothesis_extraction.py
+++ b/goedels_poetry/parsers/util/hypothesis_extraction.py
@@ -1,6 +1,64 @@
 """Hypothesis extraction utilities for subgoal extraction."""
 
 
+def extract_hypotheses_from_unsolved_goals_data(data: str) -> list[str]:
+    """
+    Extract hypothesis strings from a Lean "unsolved goals" message.
+
+    Lean (and thus Kimina) pretty-prints local contexts with newlines/indentation for long types.
+    Those indented continuation lines belong to the preceding hypothesis and must be merged.
+
+    Parameters
+    ----------
+    data: str
+        The message text, typically from a Kimina message dict's "data" field.
+
+    Returns
+    -------
+    list[str]
+        Hypothesis strings (single-line), in order, stopping before the goal line (⊢ / \u22a2).
+        Returns [] if the message is not an "unsolved goals" message.
+    """
+    if not data.startswith("unsolved goals"):
+        return []
+
+    lines = data.splitlines()
+    hypotheses: list[str] = []
+    current_parts: list[str] = []
+
+    for line in lines[1:]:
+        stripped = line.strip()
+
+        # Stop at the goal line (starts with ⊢ or \u22a2).
+        if stripped.startswith("⊢") or stripped.startswith("\u22a2"):
+            break
+
+        # Skip blanks and multi-goal case headers.
+        if not stripped:
+            continue
+        if stripped.startswith("case "):
+            continue
+
+        # Continuation lines are indented.
+        if line[:1].isspace():
+            if current_parts:
+                current_parts.append(stripped)
+            else:
+                # Defensive: ignore orphaned continuation lines.
+                continue
+            continue
+
+        # New hypothesis starts.
+        if current_parts:
+            hypotheses.append(" ".join(current_parts))
+        current_parts = [stripped]
+
+    if current_parts:
+        hypotheses.append(" ".join(current_parts))
+
+    return hypotheses
+
+
 def parse_hypothesis_strings_to_binders(hypotheses: list[str]) -> list[str]:
     """
     Convert hypothesis strings from "unsolved goals" messages to Lean binder strings.

--- a/tests/test_hypothesis_extraction_multiline.py
+++ b/tests/test_hypothesis_extraction_multiline.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from goedels_poetry.parsers.util.hypothesis_extraction import (
+    extract_hypotheses_from_unsolved_goals_data,
+    parse_hypothesis_strings_to_binders,
+)
+
+
+def test_extract_hypotheses_merges_indented_continuations() -> None:
+    # This reproduces the "h_id :" + newline + indented type formatting seen in partial.log.
+    data = (
+        "unsolved goals\n"
+        "h_id :\n"
+        "  (Finset.filter (fun x => ¬Even x) (Finset.range 10000)).prod id =\n"
+        "    ∏ x ∈ Finset.filter (fun x => ¬Even x) (Finset.range 10000), x\n"
+        "h_finset : Finset.filter (fun x => ¬Even x) (Finset.range 10000) = "
+        "Finset.image (fun k => 2 * k + 1) (Finset.range 5000)\n"
+        "h_prod_rewrite : ∏ x ∈ Finset.filter (fun x => ¬Even x) (Finset.range 10000), x = "
+        "∏ k ∈ Finset.range 5000, (2 * k + 1)\n"
+        "⊢ (Finset.filter (fun x => ¬Even x) (Finset.range 10000)).prod id = "
+        "∏ x ∈ Finset.filter (fun x => ¬Even x) (Finset.range 10000), x"
+    )
+
+    hyps = extract_hypotheses_from_unsolved_goals_data(data)
+
+    assert len(hyps) == 3
+    assert all("\n" not in h for h in hyps)
+    assert "h_id :" in hyps[0]
+    assert "prod id =" in hyps[0]
+    assert "∏ x ∈" in hyps[0]
+    assert hyps[0] != "h_id :"
+
+    binders = parse_hypothesis_strings_to_binders(hyps)
+    assert "(h_id :)" not in " ".join(binders)


### PR DESCRIPTION
Lean/Kimina may pretty-print a single hypothesis across multiple indented lines, so splitting `errors[].data` on `\n` can produce invalid binders like `(h_id :)`. Parse indented continuation lines as part of the preceding hypothesis and keep `kimina_server` as a thin wrapper.

Add a regression test reproducing the `h_id :` newline/indentation case from issue #151.

Fixes #151