### PR TITLE
Fix LangGraph mapreduce state isolation

### DIFF
--- a/goedels_poetry/agents/search_query_agent.py
+++ b/goedels_poetry/agents/search_query_agent.py
@@ -1,5 +1,6 @@
 import re
 from functools import partial
+from typing import cast
 from uuid import uuid4
 
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -82,7 +83,7 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("search_query_generator", state) for state in states["inputs"]]
+    return [Send("search_query_generator", {"item": state}) for state in states["inputs"]]
 
 
 def _is_backtracking(state: DecomposedFormalTheoremState) -> bool:
@@ -120,7 +121,7 @@ def _is_backtracking(state: DecomposedFormalTheoremState) -> bool:
     return False
 
 
-def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremState) -> DecomposedFormalTheoremStates:
+def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremStates) -> DecomposedFormalTheoremStates:
     """
     Generate search queries for the formal theorem in the passed DecomposedFormalTheoremState.
 
@@ -137,19 +138,15 @@ def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremSt
         A DecomposedFormalTheoremStates with the DecomposedFormalTheoremState with the search queries
         added to the DecomposedFormalTheoremStates "outputs" member.
     """
-    # Copy state to prevent issues with LangGraph's mapreduce implementation
-    new_state: DecomposedFormalTheoremState = {
-        **state,  # shallow copy is OK if you also copy mutables
-        "decomposition_history": list(state["decomposition_history"]),
-    }
+    theorem_state = cast(DecomposedFormalTheoremState, state["item"])
 
     # Combine the stored preamble with the formal theorem for the prompt
     formal_theorem_with_imports = combine_preamble_and_body(
-        str(new_state["preamble"]), str(new_state["formal_theorem"])
+        str(theorem_state["preamble"]), str(theorem_state["formal_theorem"])
     )
 
     # Detect if this is a backtrack scenario
-    is_backtracking = _is_backtracking(state)
+    is_backtracking = _is_backtracking(theorem_state)
 
     # Create transaction id
     transaction_id = uuid4().hex
@@ -163,7 +160,7 @@ def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremSt
             f"SEARCH_QUERY_AGENT ({transaction_id})",
             prompt,
             "search-query-backtrack",
-            attempt_num=new_state["self_correction_attempts"],
+            attempt_num=theorem_state["self_correction_attempts"],
         )
     else:
         prompt = load_prompt("search-query-initial", formal_theorem=formal_theorem_with_imports)
@@ -172,33 +169,33 @@ def _search_query_generator(llm: BaseChatModel, state: DecomposedFormalTheoremSt
             f"SEARCH_QUERY_AGENT ({transaction_id})",
             prompt,
             "search-query-initial",
-            attempt_num=new_state["self_correction_attempts"],
+            attempt_num=theorem_state["self_correction_attempts"],
         )
 
     # Add the prompt to decomposition_history
-    new_state["decomposition_history"] += [HumanMessage(content=prompt)]
+    theorem_state["decomposition_history"] += [HumanMessage(content=prompt)]
 
     # Generate search queries - LLM receives full history including the new prompt
-    response_content = llm.invoke(new_state["decomposition_history"]).content
+    response_content = llm.invoke(theorem_state["decomposition_history"]).content
 
     # Log debug response
     log_llm_response(
         f"SEARCH_QUERY_AGENT ({transaction_id})",
         str(response_content),
-        attempt_num=new_state["self_correction_attempts"],
+        attempt_num=theorem_state["self_correction_attempts"],
     )
 
     # Parse search query response
     search_queries = _parse_search_queries_response(str(response_content))
 
     # Add the search queries to the state
-    new_state["search_queries"] = search_queries
+    theorem_state["search_queries"] = search_queries
 
     # Add the LLM response to decomposition_history
-    new_state["decomposition_history"] += [AIMessage(content=str(response_content))]
+    theorem_state["decomposition_history"] += [AIMessage(content=str(response_content))]
 
     # Return a DecomposedFormalTheoremStates with state added to its outputs
-    return {"outputs": [new_state]}  # type: ignore[typeddict-item]
+    return {"outputs": [theorem_state]}  # type: ignore[typeddict-item]
 
 
 def _parse_search_queries_response(response: str) -> list[str]:

--- a/goedels_poetry/agents/state.py
+++ b/goedels_poetry/agents/state.py
@@ -4,7 +4,7 @@ from operator import add
 from typing import Annotated, Any
 
 from langchain_core.messages import AnyMessage
-from typing_extensions import Required, TypedDict
+from typing_extensions import NotRequired, Required, TypedDict
 
 from goedels_poetry.parsers.ast import AST
 from goedels_poetry.util.tree import TreeNode
@@ -127,6 +127,7 @@ class FormalTheoremProofStates(TypedDict):
     """
 
     inputs: Required[list[FormalTheoremProofState]]
+    item: NotRequired[FormalTheoremProofState]
     outputs: Required[Annotated[list[FormalTheoremProofState], add]]  # TODO: Correct annotation?
 
 
@@ -262,4 +263,5 @@ class DecomposedFormalTheoremStates(TypedDict):
     """
 
     inputs: Required[list[DecomposedFormalTheoremState]]
+    item: NotRequired[DecomposedFormalTheoremState]
     outputs: Required[Annotated[list[DecomposedFormalTheoremState], add]]  # TODO: Correct annotation?

--- a/tests/test_kimina_ast_sorries.py
+++ b/tests/test_kimina_ast_sorries.py
@@ -273,7 +273,9 @@ def test_sketch_parser_passes_goal_context(monkeypatch: pytest.MonkeyPatch) -> N
         "hole_end": None,
     }
 
-    result = sketch_parser_agent._parse_sketch("url", 0, 0, state)  # type: ignore[arg-type]
+    result = sketch_parser_agent._parse_sketch(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     assert result["outputs"][0]["ast"] is not None
 
     code_hn = result["outputs"][0]["ast"].get_named_subgoal_code("hn_nonneg")
@@ -304,7 +306,9 @@ def test_proof_parser_passes_goal_context(monkeypatch: pytest.MonkeyPatch) -> No
         "hole_end": None,
     }
 
-    result = proof_parser_agent._parse_proof("url", 0, 0, state)  # type: ignore[arg-type]
+    result = proof_parser_agent._parse_proof(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     assert result["outputs"][0]["ast"] is not None
 
     code_hn = result["outputs"][0]["ast"].get_named_subgoal_code("hn_nonneg")
@@ -357,7 +361,9 @@ def test_quantified_header_reconstructs_binders_from_sorries(monkeypatch: pytest
         "hole_end": None,
     }
 
-    result = sketch_parser_agent._parse_sketch("url", 0, 0, state)  # type: ignore[arg-type]
+    result = sketch_parser_agent._parse_sketch(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     ast = result["outputs"][0]["ast"]
     assert ast is not None
 
@@ -412,7 +418,9 @@ def test_existential_header_preserves_goal_context_binders(monkeypatch: pytest.M
         "hole_end": None,
     }
 
-    result = sketch_parser_agent._parse_sketch("url", 0, 0, state)  # type: ignore[arg-type]
+    result = sketch_parser_agent._parse_sketch(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     ast = result["outputs"][0]["ast"]
     assert ast is not None
 
@@ -446,7 +454,9 @@ def test_quantified_header_reconstructs_binders_proof_parser(monkeypatch: pytest
         "hole_end": None,
     }
 
-    result = proof_parser_agent._parse_proof("url", 0, 0, state)  # type: ignore[arg-type]
+    result = proof_parser_agent._parse_proof(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     ast = result["outputs"][0]["ast"]
     assert ast is not None
 
@@ -481,7 +491,9 @@ def test_existential_header_preserves_goal_context_binders_proof_parser(
         "hole_end": None,
     }
 
-    result = proof_parser_agent._parse_proof("url", 0, 0, state)  # type: ignore[arg-type]
+    result = proof_parser_agent._parse_proof(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     ast = result["outputs"][0]["ast"]
     assert ast is not None
 

--- a/tests/test_proof_parser_target_sig.py
+++ b/tests/test_proof_parser_target_sig.py
@@ -171,7 +171,9 @@ def test_parse_proof_formal_theorem_variants(
     _install_kimina_stub(monkeypatch, _OptionBKiminaClient)
     proof_parser_agent = importlib.import_module("goedels_poetry.agents.proof_parser_agent")
     state = _base_state(formal_theorem=formal_theorem, llm_lean_output=llm_lean_output)
-    result = proof_parser_agent._parse_proof("url", 0, 0, state)  # type: ignore[arg-type]
+    result = proof_parser_agent._parse_proof(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     out = result["outputs"][0]
     assert out["formal_proof"] == "  trivial"
 
@@ -184,7 +186,9 @@ theorem t : True := by sorry"""
     _install_kimina_stub(monkeypatch, _OptionBKiminaClient)
     proof_parser_agent = importlib.import_module("goedels_poetry.agents.proof_parser_agent")
     state = _base_state(formal_theorem=formal, llm_lean_output=proof)
-    result = proof_parser_agent._parse_proof("url", 0, 0, state)  # type: ignore[arg-type]
+    result = proof_parser_agent._parse_proof(  # type: ignore[arg-type]
+        "url", 0, 0, {"inputs": [], "outputs": [], "item": state}
+    )
     out = result["outputs"][0]
     assert out["formal_proof"] == "  trivial"
     assert "volume of a cone" in formal

--- a/tests/test_vector_db.py
+++ b/tests/test_vector_db.py
@@ -286,7 +286,7 @@ def test_query_vectordb_with_none_search_queries() -> None:
         llm_lean_output=None,
     )
 
-    result = _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], state)
+    result = _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], {"inputs": [], "outputs": [], "item": state})
 
     assert result["outputs"][0]["search_results"] is None
     assert result["outputs"][0]["search_queries"] is None
@@ -312,7 +312,7 @@ def test_query_vectordb_with_empty_search_queries() -> None:
         llm_lean_output=None,
     )
 
-    result = _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], state)
+    result = _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], {"inputs": [], "outputs": [], "item": state})
 
     assert result["outputs"][0]["search_results"] == []
     assert result["outputs"][0]["search_queries"] == []
@@ -361,7 +361,9 @@ def test_query_vectordb_with_single_query(mock_asyncio_run: MagicMock, mock_clie
         llm_lean_output=None,
     )
 
-    result = _query_vectordb("http://localhost:8001/api/v1", ["Mathlib", "Batteries"], state)
+    result = _query_vectordb(
+        "http://localhost:8001/api/v1", ["Mathlib", "Batteries"], {"inputs": [], "outputs": [], "item": state}
+    )
 
     # Verify asyncio.run was called
     assert mock_asyncio_run.call_count == 1
@@ -420,7 +422,7 @@ def test_query_vectordb_with_multiple_queries(mock_asyncio_run: MagicMock, mock_
         llm_lean_output=None,
     )
 
-    result = _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], state)
+    result = _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], {"inputs": [], "outputs": [], "item": state})
 
     # Verify asyncio.run was called 3 times (once per query)
     assert mock_asyncio_run.call_count == 3
@@ -472,7 +474,7 @@ def test_query_vectordb_propagates_exceptions(mock_asyncio_run: MagicMock, mock_
 
     # Exception should propagate
     with pytest.raises(httpx.HTTPStatusError):
-        _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], state)
+        _query_vectordb("http://localhost:8001/api/v1", ["Mathlib"], {"inputs": [], "outputs": [], "item": state})
 
 
 def test_vector_db_agent_factory() -> None:


### PR DESCRIPTION
Introduce an `item` field on FormalTheoremProofStates and DecomposedFormalTheoremStates, and update Send fan-out to pass per-task input via {"item": state}. This prevents top-level key collisions across parallel tasks that can mix subgoal fields like formal_theorem and llm_lean_output.

Remove now-unnecessary defensive shallow copies in agents and update unit tests that directly call worker functions to pass the wrapped item payload.