### PR TITLE
Fix proof pipeline state isolation and reconstruction

### DIFF
--- a/goedels_poetry/agents/proof_sketcher_agent.py
+++ b/goedels_poetry/agents/proof_sketcher_agent.py
@@ -17,6 +17,7 @@ from goedels_poetry.agents.util.common import (
     load_prompt,
 )
 from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 
 
 class ProofSketcherAgentFactory:
@@ -88,7 +89,8 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("proof_sketcher", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [Send("proof_sketcher", {"item": detach_decomposed_theorem_state(state)}) for state in states["inputs"]]
 
 
 def _extract_responses_api_content(response_content: str | list) -> str:

--- a/goedels_poetry/agents/prover_agent.py
+++ b/goedels_poetry/agents/prover_agent.py
@@ -7,7 +7,6 @@ from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, HumanMessage
 from langgraph.graph import END, START, StateGraph
 from langgraph.graph.state import CompiledStateGraph
-from langgraph.types import Send
 
 from goedels_poetry.agents.state import FormalTheoremProofState, FormalTheoremProofStates
 from goedels_poetry.agents.util.common import (
@@ -16,6 +15,7 @@ from goedels_poetry.agents.util.common import (
     load_prompt,
 )
 from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
+from goedels_poetry.agents.util.state_isolation import detach_formal_proof_state
 
 
 class ProverAgentFactory:
@@ -59,58 +59,41 @@ def _build_agent(llm: BaseChatModel) -> CompiledStateGraph:
     graph_builder = StateGraph(FormalTheoremProofStates)
 
     # Bind the llm argument of prover
-    bound_prover = partial(_prover, llm)
+    bound_prover = partial(_prover_batch, llm)
 
     # Add the nodes
     graph_builder.add_node("prover_agent", bound_prover)
 
     # Add the edges
-    graph_builder.add_conditional_edges(START, _map_edge, ["prover_agent"])
+    # NOTE: We intentionally run the "map" sequentially inside the node.
+    #
+    # LangGraph parallel fan-out has repeatedly produced cross-item state contamination in this
+    # repository (LLM output from one subgoal attached to another). Running the batch locally
+    # keeps per-item mutation isolated and makes the pipeline deterministic.
+    graph_builder.add_edge(START, "prover_agent")
     graph_builder.add_edge("prover_agent", END)
 
     return graph_builder.compile()
 
 
-def _map_edge(states: FormalTheoremProofStates) -> list[Send]:
+def _prove_one(llm: BaseChatModel, proof_state: FormalTheoremProofState) -> FormalTheoremProofState:
     """
-    Map edge that takes the members of the states["inputs"] list and dispers them to the
-    prover_agent nodes.
-
-    Parameters
-    ----------
-    states: FormalTheoremProofStates
-        The FormalTheoremProofStates containing in the "inputs" member the FormalTheoremProofState
-        instances to create the proofs for.
-
-    Returns
-    -------
-    list[Send]
-        List of Send objects each indicating the their target node and its input, singular.
-    """
-    return [Send("prover_agent", {"item": state}) for state in states["inputs"]]
-
-
-def _prover(llm: BaseChatModel, state: FormalTheoremProofStates) -> FormalTheoremProofStates:
-    """
-    Proves the formal theorem in the passed FormalTheoremProofState.
+    Prove a single formal theorem state.
 
     Parameters
     ----------
     llm: BaseChatModel
         The LLM to use for the prover agent
-    state: FormalTheoremProofState
-        The formal theorem state  with the formal theorem to be proven.
+    proof_state: FormalTheoremProofState
+        The formal theorem state with the formal theorem to be proven.
 
     Returns
     -------
-    FormalTheoremProofStates
-        A FormalTheoremProofStates with the FormalTheoremProofState with the formal proof added
-        to the FormalTheoremProofStates "outputs" member.
+    FormalTheoremProofState
+        The modified state.
     """
     # Create transaction id
     transaction_id = uuid4().hex
-
-    proof_state = cast(FormalTheoremProofState, state["item"])
 
     # Check if errors is None
     if proof_state["errors"] is None:
@@ -165,8 +148,20 @@ def _prover(llm: BaseChatModel, state: FormalTheoremProofStates) -> FormalTheore
         )
         # Do not add to proof_history on parse failure
 
-    # Return a FormalTheoremProofStates with state added to its outputs
-    return {"outputs": [proof_state]}  # type: ignore[typeddict-item]
+    return proof_state
+
+
+def _prover_batch(llm: BaseChatModel, states: FormalTheoremProofStates) -> FormalTheoremProofStates:
+    """
+    Prove all items in `states["inputs"]` sequentially.
+
+    This intentionally avoids LangGraph parallel fan-out to prevent cross-item state corruption.
+    """
+    outputs: list[FormalTheoremProofState] = []
+    for input_state in states["inputs"]:
+        detached = detach_formal_proof_state(input_state)
+        outputs.append(_prove_one(llm, detached))
+    return {"outputs": outputs}  # type: ignore[typeddict-item]
 
 
 def _extract_code_block_fallback(response: str) -> str:

--- a/goedels_poetry/agents/search_query_agent.py
+++ b/goedels_poetry/agents/search_query_agent.py
@@ -12,6 +12,7 @@ from langgraph.types import Send
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
 from goedels_poetry.agents.util.common import LLMParsingError, combine_preamble_and_body, load_prompt
 from goedels_poetry.agents.util.debug import log_llm_prompt, log_llm_response
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 
 
 class SearchQueryAgentFactory:
@@ -83,7 +84,10 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("search_query_generator", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [
+        Send("search_query_generator", {"item": detach_decomposed_theorem_state(state)}) for state in states["inputs"]
+    ]
 
 
 def _is_backtracking(state: DecomposedFormalTheoremState) -> bool:

--- a/goedels_poetry/agents/sketch_backtrack_agent.py
+++ b/goedels_poetry/agents/sketch_backtrack_agent.py
@@ -8,6 +8,7 @@ from langgraph.types import Send
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
 from goedels_poetry.agents.util.common import _format_theorem_hints_section, load_prompt
 from goedels_poetry.agents.util.debug import log_llm_prompt
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 
 
 class SketchBacktrackAgentFactory:
@@ -66,7 +67,8 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("backtrack_agent", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [Send("backtrack_agent", {"item": detach_decomposed_theorem_state(state)}) for state in states["inputs"]]
 
 
 def _backtrack(state: DecomposedFormalTheoremStates) -> DecomposedFormalTheoremStates:

--- a/goedels_poetry/agents/sketch_checker_agent.py
+++ b/goedels_poetry/agents/sketch_checker_agent.py
@@ -10,6 +10,7 @@ from goedels_poetry.agents.state import DecomposedFormalTheoremState, Decomposed
 from goedels_poetry.agents.util.common import combine_preamble_and_body, get_error_str
 from goedels_poetry.agents.util.debug import log_kimina_response
 from goedels_poetry.agents.util.kimina_server import parse_kimina_check_response
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 
 
 class SketchCheckerAgentFactory:
@@ -89,7 +90,8 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("check_sketch_agent", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [Send("check_sketch_agent", {"item": detach_decomposed_theorem_state(state)}) for state in states["inputs"]]
 
 
 def _check_sketch(

--- a/goedels_poetry/agents/sketch_corrector_agent.py
+++ b/goedels_poetry/agents/sketch_corrector_agent.py
@@ -8,6 +8,7 @@ from langgraph.types import Send
 from goedels_poetry.agents.state import DecomposedFormalTheoremState, DecomposedFormalTheoremStates
 from goedels_poetry.agents.util.common import load_prompt
 from goedels_poetry.agents.util.debug import log_llm_prompt
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 
 
 class SketchCorrectorAgentFactory:
@@ -66,7 +67,8 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("corrector_agent", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [Send("corrector_agent", {"item": detach_decomposed_theorem_state(state)}) for state in states["inputs"]]
 
 
 def _corrector(state: DecomposedFormalTheoremStates) -> DecomposedFormalTheoremStates:

--- a/goedels_poetry/agents/sketch_decomposition_agent.py
+++ b/goedels_poetry/agents/sketch_decomposition_agent.py
@@ -15,6 +15,7 @@ from goedels_poetry.agents.state import (
 )
 from goedels_poetry.agents.util.debug import log_kimina_response
 from goedels_poetry.agents.util.kimina_server import parse_kimina_check_response
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 from goedels_poetry.parsers.ast import AST
 from goedels_poetry.parsers.util.high_level.subgoal_extraction_v2 import (
     extract_subgoal_with_check_responses,
@@ -297,7 +298,11 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("sketch_decomposition_agent", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [
+        Send("sketch_decomposition_agent", {"item": detach_decomposed_theorem_state(state)})
+        for state in states["inputs"]
+    ]
 
 
 def _sketch_decomposer(

--- a/goedels_poetry/agents/sketch_parser_agent.py
+++ b/goedels_poetry/agents/sketch_parser_agent.py
@@ -11,6 +11,7 @@ from goedels_poetry.agents.state import DecomposedFormalTheoremState, Decomposed
 from goedels_poetry.agents.util.common import combine_preamble_and_body, remove_default_imports_from_ast
 from goedels_poetry.agents.util.debug import log_kimina_response
 from goedels_poetry.agents.util.kimina_server import is_no_usable_ast, parse_kimina_ast_code_response
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 from goedels_poetry.parsers.ast import AST
 from goedels_poetry.parsers.util.foundation.decl_extraction import (
     extract_preamble_from_ast,
@@ -96,7 +97,8 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating the their target node and its input, singular.
     """
-    return [Send("parser_agent", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [Send("parser_agent", {"item": detach_decomposed_theorem_state(state)}) for state in states["inputs"]]
 
 
 def _actionable_suffix(parsed: dict, code_preview: str) -> str:

--- a/goedels_poetry/agents/util/state_isolation.py
+++ b/goedels_poetry/agents/util/state_isolation.py
@@ -1,0 +1,62 @@
+"""
+Helpers for isolating per-item state in LangGraph map/reduce fan-out.
+
+The LangGraph Send API and state merging operate on Python objects. If we pass live
+TreeNode dicts that participate in a cyclic object graph (e.g. via `parent` pointers
+and `children` dicts), then parallel execution can observe shared mutable references
+and can also trigger implementation-dependent copying/merging behaviour.
+
+To keep map/reduce robust, we fan out *detached, acyclic* per-item payloads and
+later reattach them into the canonical proof tree by id.
+"""
+
+from __future__ import annotations
+
+from typing import cast
+
+from goedels_poetry.agents.state import (
+    APISearchResponseTypedDict,
+    DecomposedFormalTheoremState,
+    FormalTheoremProofState,
+)
+
+
+def detach_formal_proof_state(state: FormalTheoremProofState) -> FormalTheoremProofState:
+    """
+    Return an acyclic copy of a FormalTheoremProofState for parallel processing.
+
+    - Clears the `parent` pointer to break cycles.
+    - Copies `proof_history` so worker appends are isolated from any shared list.
+
+    The returned dict is intended to be merged back into the canonical tree by id
+    (see GoedelsPoetryStateManager._reconstruct_tree()).
+    """
+    detached = dict(state)
+    detached["parent"] = None
+    # Defensive: ensure history list is not shared by reference.
+    detached["proof_history"] = list(state.get("proof_history", []))
+    return cast(FormalTheoremProofState, detached)
+
+
+def detach_decomposed_theorem_state(state: DecomposedFormalTheoremState) -> DecomposedFormalTheoremState:
+    """
+    Return an acyclic copy of a DecomposedFormalTheoremState for parallel processing.
+
+    - Clears the `parent` pointer to break cycles.
+    - Copies list fields that are commonly appended to by workers (e.g. message history).
+    - Copies `children` mapping (shallow) so workers can't mutate the canonical mapping.
+
+    NOTE: Decomposition-stage workers that *add* children will still populate the copied
+    `children` mapping on the detached state; the resulting node will be merged back
+    into the canonical proof tree by id.
+    """
+    detached = dict(state)
+    detached["parent"] = None
+    detached["children"] = dict(state.get("children", {}))
+    detached["decomposition_history"] = list(state.get("decomposition_history", []))
+    if state.get("search_queries") is not None:
+        detached["search_queries"] = list(cast(list[str], state["search_queries"]))
+    search_results = state.get("search_results")
+    if search_results is not None:
+        detached["search_results"] = list(cast(list[APISearchResponseTypedDict], search_results))
+    return cast(DecomposedFormalTheoremState, detached)

--- a/goedels_poetry/agents/vector_db_agent.py
+++ b/goedels_poetry/agents/vector_db_agent.py
@@ -12,6 +12,7 @@ from goedels_poetry.agents.state import (
     DecomposedFormalTheoremStates,
 )
 from goedels_poetry.agents.util.debug import log_vectordb_response
+from goedels_poetry.agents.util.state_isolation import detach_decomposed_theorem_state
 
 try:
     # Optional dependency: `lean_explore` is only required when actually querying a LeanExplore server.
@@ -106,7 +107,8 @@ def _map_edge(states: DecomposedFormalTheoremStates) -> list[Send]:
     list[Send]
         List of Send objects each indicating their target node and its input, singular.
     """
-    return [Send("vector_db_agent", {"item": state}) for state in states["inputs"]]
+    # Fan out detached per-item payloads to avoid sharing cyclic proof-tree references.
+    return [Send("vector_db_agent", {"item": detach_decomposed_theorem_state(state)}) for state in states["inputs"]]
 
 
 def _query_vectordb(

--- a/tests/test_extract_proof_body_preserves_indent.py
+++ b/tests/test_extract_proof_body_preserves_indent.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from goedels_poetry.state import GoedelsPoetryState, GoedelsPoetryStateManager
+
+
+def test_extract_proof_body_ast_guided_preserves_leading_indent() -> None:
+    """
+    Regression test: do not strip leading indentation from a leaf `formal_proof`.
+
+    Proof bodies often contain nested `have ... := by` blocks where subsequent tactics (e.g. `apply h₄`)
+    must be aligned with the `have` line to be outside the nested `by` block. If we strip the first
+    line's leading spaces but leave later lines indented, the relative structure breaks and
+    reconstruction can fail with "All indentation strategies failed".
+    """
+    # Minimal manager; the helper under test doesn't depend on the stored state content.
+    manager = GoedelsPoetryStateManager(GoedelsPoetryState(informal_theorem="dummy"))
+
+    formal_proof = "  have h₄ : True := by\n    trivial\n\n  apply h₄"
+    leaf = {
+        "id": "x",
+        "parent": None,
+        "depth": 0,
+        "formal_theorem": "theorem t : True := by sorry",
+        "preamble": "",
+        "syntactic": True,
+        "formal_proof": formal_proof,
+        "proved": True,
+        "errors": None,
+        "ast": None,
+        "self_correction_attempts": 0,
+        "proof_history": [],
+        "pass_attempts": 0,
+        "hole_name": "hv_subst",
+        "hole_start": 0,
+        "hole_end": 0,
+        "llm_lean_output": None,
+    }
+
+    extracted = manager._extract_proof_body_ast_guided(  # type: ignore[arg-type]
+        leaf,
+        kimina_client=MagicMock(),
+        server_timeout=0,
+    )
+
+    assert extracted.startswith("  have "), "Leading indentation should be preserved for leaf proofs"
+    # And ensure the later line remains aligned (still has 2 spaces).
+    assert "\n  apply h₄" in extracted


### PR DESCRIPTION
- Avoid LangGraph cross-item state contamination by detaching per-item proof/sketch payloads and running proof pipeline stages sequentially inside a single node.
- Preserve leading indentation for leaf proof bodies and make AST-guided hole replacement treat post-parse hole-count inconsistencies as strategy failures (try the next indentation strategy).
- When extracting standalone subgoal lemmas, rewrite named-have hypothesis types from the sketch AST to preserve coercions/types dropped by "unsolved goals" pretty-printing.
- Add regression tests for indentation preservation and hypothesis type rewriting.