### PR TITLE
Fix proof parser failure when prover uses theorem vs lemma for subgoals

### DIFF
--- a/goedels_poetry/data/prompts/goedel-prover-v2-initial.md
+++ b/goedels_poetry/data/prompts/goedel-prover-v2-initial.md
@@ -11,3 +11,5 @@ IMPORTANT: When you've completed your planning you should output your proof of t
 IMPORTANT: Your proof should actually prove the theorem or lemma using Lean 4 code. It should not contain sorry, admit, or any other Lean 4 tactics that indicate an incomplete proof.
 
 IMPORTANT: Your completion should contain ONLY the theorem/def and its proof. Do NOT include any import statements or preamble (like `import Mathlib`, `open`, `set_option`, `noncomputable section`, etc.) as these are already provided in the code above. Start directly with your theorem/definition/lemma declaration.
+
+IMPORTANT: Preserve the declaration header exactly as given (including whether it is `theorem` vs `lemma`, the declaration name, binders, and the statement type). Only change the proof body.

--- a/goedels_poetry/data/prompts/goedel-prover-v2-subsequent.md
+++ b/goedels_poetry/data/prompts/goedel-prover-v2-subsequent.md
@@ -9,3 +9,5 @@ IMPORTANT: When you've completed your detailed analysis of the error message you
 IMPORTANT: Your proof should actually prove the theorem or lemma using Lean 4 code. It should not contain sorry, admit, or any other Lean 4 tactics that indicate an incomplete proof.
 
 IMPORTANT: Your corrected proof should contain ONLY the theorem/def and its proof. Do NOT include any import statements or preamble (like `import Mathlib`, `open`, `set_option`, `noncomputable section`, etc.). Start directly with your theorem/definition/lemma declaration.
+
+IMPORTANT: Preserve the declaration header exactly as given (including whether it is `theorem` vs `lemma`, the declaration name, binders, and the statement type). Only change the proof body.

--- a/tests/test_decl_extraction_robustness.py
+++ b/tests/test_decl_extraction_robustness.py
@@ -116,6 +116,28 @@ theorem target (x : Nat) : x = x := by rfl
         body = extract_proof_body_from_ast(ast, target_sig)
         assert body == " rfl"
 
+    def test_signature_matching_lemma_theorem_equivalence_target_is_lemma(self, kimina_server_url: str) -> None:
+        """Allow matching lemma target against theorem proof declaration."""
+        code = f"""{DEFAULT_IMPORTS}
+theorem target : True := by
+  trivial
+"""
+        ast = _create_ast(code, kimina_server_url)
+        target_sig = "lemma target : True"
+        body = extract_proof_body_from_ast(ast, target_sig)
+        assert body == "  trivial"
+
+    def test_signature_matching_lemma_theorem_equivalence_target_is_theorem(self, kimina_server_url: str) -> None:
+        """Allow matching theorem target against lemma proof declaration."""
+        code = f"""{DEFAULT_IMPORTS}
+lemma target : True := by
+  trivial
+"""
+        ast = _create_ast(code, kimina_server_url)
+        target_sig = "theorem target : True"
+        body = extract_proof_body_from_ast(ast, target_sig)
+        assert body == "  trivial"
+
 
 @pytest.mark.usefixtures("skip_if_no_lean")
 class TestExtractSignatureFromAst:


### PR DESCRIPTION
Decomposition always emits standalone subgoals as "lemma" (subgoal_extraction_v2), while the prover may return "theorem" for the same statement. Signature matching in extract_proof_body_from_ast was exact, so lemma/theorem mismatch caused "Structural extraction failed for target signature" (e.g. numbertheory_4x3m7y3neq2003).

- decl_extraction: Add two-stage matching in extract_proof_body_from_ast. Stage A keeps existing strict match (whitespace-normalized). Stage B runs only if A fails and treats lemma/theorem as equivalent by canonicalizing the declaration kind token before comparison. Log at debug when the relaxed match is used. extract_signature_from_ast is unchanged.

- Prover prompts (goedel-prover-v2-initial, goedel-prover-v2-subsequent): Ask to preserve the declaration header exactly (theorem vs lemma, name, binders, type) and only change the proof body.

- tests: Add test_signature_matching_lemma_theorem_equivalence_target_is_lemma and test_signature_matching_lemma_theorem_equivalence_target_is_theorem to lock in lemma/theorem equivalence behavior.