### PR TITLE
Fix proof parser failure when target has space before ) in binders

### DIFF
--- a/goedels_poetry/parsers/util/high_level/subgoal_extraction_v2.py
+++ b/goedels_poetry/parsers/util/high_level/subgoal_extraction_v2.py
@@ -213,7 +213,8 @@ def _extract_main_body_info(ast: AST) -> tuple[str, str]:
     type_ast = __extract_type_ast(theorem_node)
     if type_ast is not None:
         type_ast = __strip_leading_colon(type_ast)
-        type_str = _ast_to_code(type_ast)
+        # _ast_to_code preserves token trailing whitespace; strip to avoid types ending in " ... x ".
+        type_str = _ast_to_code(type_ast).strip()
     else:
         # Type extraction fallback: __extract_type_ast() returns None for:
         # - match bindings: Types are inferred from pattern matching, not in AST
@@ -255,7 +256,9 @@ def _extract_have_statement_info(ast: AST, target_subgoal_name: str) -> tuple[st
     type_ast = __extract_type_ast(have_node)
     if type_ast is not None:
         type_ast = __strip_leading_colon(type_ast)
-        type_str = _ast_to_code(type_ast)
+        # _ast_to_code preserves token trailing whitespace; strip to avoid types ending in " ... x ".
+        # These trailing spaces can later produce binders like `(hx : 1 < x )` when wrapped.
+        type_str = _ast_to_code(type_ast).strip()
     else:
         # Type extraction fallback: __extract_type_ast() returns None for:
         # - match bindings: Types are inferred from pattern matching, not in AST

--- a/goedels_poetry/parsers/util/hypothesis_extraction.py
+++ b/goedels_poetry/parsers/util/hypothesis_extraction.py
@@ -83,4 +83,6 @@ def parse_hypothesis_strings_to_binders(hypotheses: list[str]) -> list[str]:
         List of binder strings with parentheses (e.g., ["(n : Z)", "(hn : n > 1)"]).
         The order is preserved from the input list.
     """
-    return [f"({hypothesis})" for hypothesis in hypotheses]
+    # Strip leading/trailing whitespace so we don't synthesize binders like `(hx : 1 < x )`
+    # when the hypothesis type string ends with trailing spaces.
+    return [f"({hypothesis.strip()})" for hypothesis in hypotheses]

--- a/tests/test_decl_extraction_robustness.py
+++ b/tests/test_decl_extraction_robustness.py
@@ -138,6 +138,29 @@ lemma target : True := by
         body = extract_proof_body_from_ast(ast, target_sig)
         assert body == "  trivial"
 
+    def test_signature_matching_closing_delim_whitespace_equivalence(self, kimina_server_url: str) -> None:
+        """Allow matching when target has whitespace before closing delimiters (e.g. `x )`)."""
+        code = f"""{DEFAULT_IMPORTS}
+theorem target (x : Nat) (hx : 1 < x) : True := by
+  trivial
+"""
+        ast = _create_ast(code, kimina_server_url)
+        # Note the space before `)` in `(hx : 1 < x )`
+        target_sig = "theorem target (x : Nat) (hx : 1 < x ) : True"
+        body = extract_proof_body_from_ast(ast, target_sig)
+        assert body == "  trivial"
+
+    def test_closing_delim_whitespace_fallback_does_not_overmatch(self, kimina_server_url: str) -> None:
+        """Ensure delimiter-whitespace relaxation does not match different statement types."""
+        code = f"""{DEFAULT_IMPORTS}
+theorem target (x : Nat) (hx : 1 < x) : True := by
+  trivial
+"""
+        ast = _create_ast(code, kimina_server_url)
+        target_sig = "theorem target (x : Nat) (hx : 1 < x ) : False"
+        body = extract_proof_body_from_ast(ast, target_sig)
+        assert body is None
+
 
 @pytest.mark.usefixtures("skip_if_no_lean")
 class TestExtractSignatureFromAst:


### PR DESCRIPTION
Standalone lemmas built from check-response hypotheses or AST-derived types could include trailing spaces (e.g. "(hx : 1 < x )"). The proof declaration from the prover typically has no space before ")". Signature matching uses " ".join(s.split()), so "x )" vs "x)" tokenize differently and the match fails (e.g. aime_1983_p1, hlogw_eq_24logx).

- subgoal_extraction_v2: Strip _ast_to_code(type_ast) when building type_str for main-body and have-statement subgoals so token-trailing whitespace is not baked into standalone lemma binders.

- hypothesis_extraction: Strip each hypothesis before wrapping in parentheses in parse_hypothesis_strings_to_binders() so binders are never "(hx : 1 < x )".

- decl_extraction: Add Stage C fallback in extract_proof_body_from_ast(): if strict and lemma/theorem matching fail, try matching after removing whitespace immediately before closing delimiters ) ] }. Log at debug when this fallback is used.

- tests: Add test_signature_matching_closing_delim_whitespace_equivalence and test_closing_delim_whitespace_fallback_does_not_overmatch.