### PR TITLE
fix: clear proof and sketch artifacts on pass restart and backtrack

### DIFF
--- a/goedels_poetry/agents/prover_agent.py
+++ b/goedels_poetry/agents/prover_agent.py
@@ -158,6 +158,8 @@ def _prove_one(llm: BaseChatModel, proof_state: FormalTheoremProofState) -> Form
         proof_state["proof_history"] += [AIMessage(content=raw_code)]
     except LLMParsingError:
         # Set parse failure markers - state manager will handle requeueing and attempt increments
+        # Also clear llm_lean_output so a prior successful extraction can't be reused accidentally.
+        proof_state["llm_lean_output"] = None
         proof_state["formal_proof"] = None
         proof_state["errors"] = (
             "Malformed LLM response: unable to parse proof body from LLM output. "

--- a/goedels_poetry/state.py
+++ b/goedels_poetry/state.py
@@ -887,9 +887,14 @@ class GoedelsPoetryStateManager:
         to start a fresh proof attempt with the initial prompt.
         """
         proof["self_correction_attempts"] = 0
+        # Clear any derived artifacts from a previous attempt/pass so stale outputs can't leak
+        # into later validation/reconstruction.
+        proof["proved"] = False
         proof["errors"] = None
         proof["proof_history"] = []
-        # reset additional state as needed
+        proof["llm_lean_output"] = None
+        proof["formal_proof"] = None
+        proof["ast"] = None
 
     def _queue_proofs_for_decomposition(self, proofs_too_difficult: list[FormalTheoremProofState]) -> None:
         """
@@ -1379,9 +1384,15 @@ class GoedelsPoetryStateManager:
         node : DecomposedFormalTheoremState
             The node to prepare for re-sketching
         """
+        # Backtracking means we are restarting the sketch/decompose loop for this node.
+        # Reset any attempt counter and derived artifacts so stale values cannot leak
+        # into the next sketching/parsing/validation cycle.
+        node["self_correction_attempts"] = 0
+        node["llm_lean_output"] = None
+
         # Clear children (they will be removed from tree separately)
         node["children"] = {}
-        # Clear sketch-related fields
+        # Defensive: clear sketch "result" fields
         node["proof_sketch"] = None
         node["syntactic"] = False
         node["errors"] = None


### PR DESCRIPTION
Prevent stale llm_lean_output, formal_proof, ast, and proved from leaking across proof pass restarts and decomposition backtracks so reconstruction cannot reuse an older, invalid proof body.

Proof side:
- _reset_self_correction_state(): clear proved, llm_lean_output, formal_proof, ast (in addition to attempts, errors, proof_history).
- prover_agent: on LLMParsingError, set llm_lean_output = None.

Decomposition side:
- _prepare_node_for_resketching(): set self_correction_attempts = 0 and llm_lean_output = None; defensively clear proof_sketch, syntactic, errors, ast, search_queries, search_results (and children).