### PR TITLE
fix(ast_to_code): suppress Kimina [anonymous] sentinel

### DIFF
--- a/goedels_poetry/parsers/util/collection_and_analysis/variable_renaming.py
+++ b/goedels_poetry/parsers/util/collection_and_analysis/variable_renaming.py
@@ -375,7 +375,13 @@ def _rename_in_node_recursive(
         if _should_rename_identifier(node, rename_map, parent_is_qualified, in_declaration):
             val = node.get("val")
             if isinstance(val, str):
-                node["val"] = rename_map[val]
+                new_name = rename_map[val]
+                node["val"] = new_name
+                # Keep rawVal consistent when present (Kimina often provides both).
+                # This avoids serializers that prefer rawVal from "losing" the rename.
+                raw = node.get("rawVal")
+                if isinstance(raw, str):
+                    node["rawVal"] = new_name
 
         # Process children based on whether this is a declaration
         is_decl = _is_declaration_kind(kind)

--- a/tests/test_ast_to_code_rewrite_awareness.py
+++ b/tests/test_ast_to_code_rewrite_awareness.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from goedels_poetry.parsers.util.foundation.ast_to_code import _ast_to_code
+
+
+def test_ast_to_code_suppresses_kimina_anonymous_sentinel() -> None:
+    # Kimina can emit `val == "[anonymous]"` (with rawVal == "") for anonymous binders.
+    # We must NOT serialize this sentinel into Lean code.
+    node = {"val": "[anonymous]", "rawVal": "", "info": {"leading": "", "trailing": ""}}
+    assert _ast_to_code(node) == ""
+
+
+def test_ast_to_code_prefers_rawval_when_val_unchanged() -> None:
+    # When AST node has a stable token, rawVal is the closest to original surface text.
+    node = {"val": "x", "rawVal": "x", "info": {"leading": "", "trailing": ""}}
+    assert _ast_to_code(node) == "x"
+
+
+def test_ast_to_code_is_rewrite_aware_when_val_differs_from_rawval() -> None:
+    # After programmatic AST rewrites (e.g. variable renaming), val can differ from rawVal.
+    # In that case we should serialize val, otherwise the rewrite is lost.
+    node = {"val": "x_hole1_deadbeef", "rawVal": "x", "info": {"leading": "", "trailing": ""}}
+    assert _ast_to_code(node) == "x_hole1_deadbeef"


### PR DESCRIPTION
Prefer `rawVal` when present and treat `val == "[anonymous]"` as “emit nothing” so AST-to-code reconstruction doesn’t generate invalid Lean like `have [anonymous]: ...`.