### PR TITLE
Add AST-based guardrail to reject sketches with nested sorry holes

### DIFF
--- a/goedels_poetry/agents/sketch_checker_agent.py
+++ b/goedels_poetry/agents/sketch_checker_agent.py
@@ -42,6 +42,71 @@ def _mark_unsyntactic_with_error(theorem_state: DecomposedFormalTheoremState, me
     theorem_state["errors"] = message
 
 
+# AST-based guardrail: reject sketches that introduce nested `sorry` holes inside structured
+# subproofs (e.g. `calc` steps) for a named `have`. The decomposition+reconstruction pipeline
+# assumes each named subgoal has a top-level placeholder `have h : T := by sorry` so the child
+# proof of `T` can be inlined at that hole. A nested `sorry` (e.g. inside `calc ... := by sorry`)
+# violates that assumption and can cause reconstruction to fail even when all children are proved.
+_CALC_NESTING_KINDS: set[str] = {
+    # Observed in Kimina AST for `calc` tactic blocks.
+    "Lean.calcTactic",
+    "Lean.calcSteps",
+    "Lean.calcFirstStep",
+    "Lean.calcStep",
+}
+
+
+def _find_haves_with_only_nested_sorry(ast: object) -> list[str]:  # noqa: C901
+    """
+    Return have-names whose proof contains one or more `sorry` nodes, all of which appear
+    under a nested proof construct (currently: under `calc`).
+
+    This is intentionally AST-based (no regex/text parsing of Lean).
+    """
+    from goedels_poetry.parsers.util.names_and_bindings.anonymous_haves import __collect_anonymous_haves
+    from goedels_poetry.parsers.util.names_and_bindings.name_extraction import _extract_have_id_name
+
+    if not isinstance(ast, dict | list):
+        return []
+
+    anon_have_by_id, _anon_by_name = __collect_anonymous_haves(ast)
+    counts: dict[str, dict[str, int]] = {}
+
+    def record(have_name: str, *, nested: bool) -> None:
+        slot = counts.setdefault(have_name, {"outer": 0, "nested": 0})
+        if nested:
+            slot["nested"] += 1
+        else:
+            slot["outer"] += 1
+
+    def rec(node: object, *, current_have: str | None, in_nested: bool) -> None:
+        if isinstance(node, dict):
+            kind = node.get("kind")
+            kind_str = kind if isinstance(kind, str) else None
+            in_nested2 = in_nested or (kind_str in _CALC_NESTING_KINDS)
+
+            if kind_str == "Lean.Parser.Tactic.tacticHave_":
+                have_name = _extract_have_id_name(node) or anon_have_by_id.get(id(node))
+                current_have = have_name
+
+            if kind_str == "Lean.Parser.Tactic.tacticSorry" and current_have:
+                record(current_have, nested=in_nested2)
+
+            for v in node.values():
+                rec(v, current_have=current_have, in_nested=in_nested2)
+        elif isinstance(node, list):
+            for it in node:
+                rec(it, current_have=current_have, in_nested=in_nested)
+
+    rec(ast, current_have=None, in_nested=False)
+
+    violations: list[str] = []
+    for have_name, c in counts.items():
+        if c["nested"] > 0 and c["outer"] == 0:
+            violations.append(have_name)
+    return sorted(violations)
+
+
 def _try_extract_target_signature(
     *,
     kimina_client: KiminaClient,
@@ -114,6 +179,30 @@ def _maybe_flag_downstream_parser_errors(
         _mark_unsyntactic_with_error(
             theorem_state,
             "Kimina failed to parse proof" + actionable_suffix(parsed_ast or {}, normalized_sketch_with_imports),
+        )
+        return
+
+    # Guardrail: reject sketches that contain only nested `sorry` holes for a named `have`.
+    # Example of a violating pattern:
+    #   have h_main : T := by
+    #     calc
+    #       ... := by sorry
+    #
+    # In such sketches, the only `sorry` attributed to `h_main` is the one inside the `calc` step,
+    # but the child proof for `h_main` will be a proof of `T`, which cannot be inlined at the
+    # calc-step goal. This leads to "All indentation strategies failed" reconstruction failures.
+    violating_haves = _find_haves_with_only_nested_sorry(parsed_ast.get("ast"))
+    if violating_haves:
+        names_preview = ", ".join(violating_haves[:6]) + ("..." if len(violating_haves) > 6 else "")
+        _mark_unsyntactic_with_error(
+            theorem_state,
+            (
+                "Sketch rejected: found nested `sorry` hole(s) inside structured subproofs (e.g. `calc`) "
+                "for the following subgoal(s): "
+                f"{names_preview}. "
+                "Each subgoal `have h : T := by ...` must use a single top-level placeholder "
+                "`have h : T := by\\n  sorry` (no nested `sorry` inside `calc`/subproof steps)."
+            ),
         )
         return
 

--- a/goedels_poetry/data/prompts/decomposer-backtrack.md
+++ b/goedels_poetry/data/prompts/decomposer-backtrack.md
@@ -12,6 +12,15 @@ Before producing the new Lean 4 code to sketch a proof, provide:
 2. A description of the new strategy you will try
 3. An explanation of how this new approach differs from the previous one
 
+IMPORTANT constraint (must follow):
+- Never place a `sorry` inside a nested subproof (e.g. inside a `calc` step `... := by sorry`, inside `match`/`cases` branches, or inside any nested `by` block).
+- If a subgoal is unproven, it must end with a single top-level placeholder:
+  ```lean4
+  have h_name : T := by
+    sorry
+  ```
+  If you want to outline a structured proof (like `calc`), put the outline in comments, but keep the proof itself as `by sorry`.
+
 Note that the theorems listed below may differ from those presented in previous attempts, as a new search strategy was used to find potentially useful theorems for this different decomposition approach. These theorems may or may not be new compared to previous attempts, but they represent theorems identified specifically for trying this alternative strategy. Consider how these theorems might be useful in your new decomposition approach.
 
 {{ theorem_hints_section }}

--- a/goedels_poetry/data/prompts/decomposer-initial.md
+++ b/goedels_poetry/data/prompts/decomposer-initial.md
@@ -11,6 +11,12 @@ You are a Lean 4 formal theorem prover assistant. Your task is to take a Lean th
 9. Do not introduce auxiliary lemmas or any other statements not subordinate to the main Lean 4 theorem.
 10. In particular do not introduce an unexpected identifier or unexpected command such as "Complex" before the main Lean 4 theorem statement.
 11. As in the examples below, do not introduce any preamble (e.g. import, set_option, open, or other similar statements) before the decomposed theorem.
+12. IMPORTANT: Never place a `sorry` inside a nested subproof (e.g. inside a `calc` step `... := by sorry`, inside `match`/`cases` branches, or inside any nested `by` block). If a subgoal is unproven, it must end with a single top-level placeholder of the form:
+    ```lean4
+    have h_name : T := by
+      sorry
+    ```
+    If you want to outline a `calc`/structured proof, put the outline in comments, but keep the proof itself as `by sorry`.
 
 When decomposing the proof, you may find it helpful to use existing proven theorems from the list below. For example:
 - You might use an existing theorem like `Nat.add_comm` to simplify expressions involving addition

--- a/goedels_poetry/data/prompts/decomposer-subsequent.md
+++ b/goedels_poetry/data/prompts/decomposer-subsequent.md
@@ -3,3 +3,12 @@ The proof sketch (Round {{ prev_round_num }}) is not correct. Following is the c
 {{ error_message_for_prev_round }}
 
 Before producing the Lean 4 code to sketch a proof to the given theorem, provide a detailed analysis of the error message.
+
+IMPORTANT constraint (must follow):
+- Never place a `sorry` inside a nested subproof (e.g. inside a `calc` step `... := by sorry`, inside `match`/`cases` branches, or inside any nested `by` block).
+- If a subgoal is unproven, it must end with a single top-level placeholder:
+  ```lean4
+  have h_name : T := by
+    sorry
+  ```
+  If you want to outline a structured proof (like `calc`), put the outline in comments, but keep the proof itself as `by sorry`.

--- a/tests/test_checker_parser_failure_conditions.py
+++ b/tests/test_checker_parser_failure_conditions.py
@@ -145,6 +145,238 @@ def test_sketch_checker_flags_kimina_ast_parse_failure(monkeypatch: pytest.Monke
     assert "Kimina failed to parse proof" in theorem_state["errors"]
 
 
+def test_sketch_checker_rejects_nested_sorry_in_calc_subproof(monkeypatch: pytest.MonkeyPatch) -> None:
+    """
+    Regression test for the reconstruction failure mode:
+    a named `have h : T := by ...` contains only a nested `sorry` inside a `calc` step.
+
+    Such sketches typecheck (pass Kimina) but violate downstream decomposition/reconstruction
+    assumptions, so the sketch checker should reject them with a clear error.
+    """
+    _install_kimina_stub(monkeypatch)
+    from goedels_poetry.agents import sketch_checker_agent as mod
+
+    # Minimal AST with a named have `h_main` whose only sorry is under `Lean.calcTactic`.
+    ast_with_nested_sorry = {
+        "commands": [
+            {
+                "kind": "Lean.Parser.Command.theorem",
+                "args": [
+                    {"val": "theorem"},
+                    {"kind": "Lean.Parser.Command.declId", "args": [{"val": "t"}]},
+                    {"val": ":"},
+                    {"val": "True"},
+                    {"val": ":="},
+                    {
+                        "kind": "Lean.Parser.Term.byTactic",
+                        "args": [
+                            {"val": "by"},
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                "args": [
+                                    {
+                                        "kind": "Lean.Parser.Tactic.tacticHave_",
+                                        "args": [
+                                            {"val": "have"},
+                                            {
+                                                "kind": "Lean.Parser.Term.haveDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveIdDecl",
+                                                        "args": [
+                                                            {
+                                                                "kind": "Lean.Parser.Term.haveId",
+                                                                "args": [{"val": "h_main"}],
+                                                            }
+                                                        ],
+                                                    },
+                                                    {"val": ":"},
+                                                    {"val": "1 = 1"},
+                                                ],
+                                            },
+                                            {"val": ":="},
+                                            {
+                                                "kind": "Lean.Parser.Term.byTactic",
+                                                "args": [
+                                                    {"val": "by"},
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                        "args": [
+                                                            {
+                                                                "kind": "Lean.calcTactic",
+                                                                "args": [
+                                                                    {
+                                                                        "kind": "Lean.calcSteps",
+                                                                        "args": [
+                                                                            {
+                                                                                "kind": "Lean.calcFirstStep",
+                                                                                "args": [
+                                                                                    {"val": "1 = 1"},
+                                                                                    {"val": ":="},
+                                                                                    {
+                                                                                        "kind": "Lean.Parser.Term.byTactic",
+                                                                                        "args": [
+                                                                                            {"val": "by"},
+                                                                                            {
+                                                                                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                                                                "args": [
+                                                                                                    {
+                                                                                                        "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                                                                        "args": [
+                                                                                                            {
+                                                                                                                "val": "sorry",
+                                                                                                                "info": {
+                                                                                                                    "pos": [
+                                                                                                                        0,
+                                                                                                                        5,
+                                                                                                                    ]
+                                                                                                                },
+                                                                                                            }
+                                                                                                        ],
+                                                                                                    }
+                                                                                                ],
+                                                                                            },
+                                                                                        ],
+                                                                                    },
+                                                                                ],
+                                                                            }
+                                                                        ],
+                                                                    }
+                                                                ],
+                                                            }
+                                                        ],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+    theorem_state = {
+        "syntactic": True,
+        "errors": "",
+        "preamble": "import Foo",
+        "formal_theorem": "theorem t : True := by trivial",
+        "proof_sketch": "dummy",
+        "ast": {"dummy": True},
+    }
+
+    kimina = _FakeKiminaClient(ast_code_results=[{"error": None, "ast": ast_with_nested_sorry}])
+
+    mod._maybe_flag_downstream_parser_errors(
+        theorem_state=theorem_state,
+        kimina_client=kimina,
+        server_timeout=1,
+        raw_output="theorem t : True := by\n  have h_main : 1 = 1 := by\n    calc\n      1 = 1 := by\n        sorry\n  trivial\n",
+    )
+
+    assert theorem_state["syntactic"] is False
+    assert theorem_state["proof_sketch"] is None
+    assert theorem_state["ast"] is None
+    assert isinstance(theorem_state["errors"], str)
+    assert "Sketch rejected" in theorem_state["errors"]
+    assert "h_main" in theorem_state["errors"]
+
+
+def test_sketch_checker_allows_top_level_sorry_in_have(monkeypatch: pytest.MonkeyPatch) -> None:
+    _install_kimina_stub(monkeypatch)
+    from goedels_poetry.agents import sketch_checker_agent as mod
+
+    ast_with_outer_sorry = {
+        "commands": [
+            {
+                "kind": "Lean.Parser.Command.theorem",
+                "args": [
+                    {"val": "theorem"},
+                    {"kind": "Lean.Parser.Command.declId", "args": [{"val": "t"}]},
+                    {"val": ":"},
+                    {"val": "True"},
+                    {"val": ":="},
+                    {
+                        "kind": "Lean.Parser.Term.byTactic",
+                        "args": [
+                            {"val": "by"},
+                            {
+                                "kind": "Lean.Parser.Tactic.tacticSeq",
+                                "args": [
+                                    {
+                                        "kind": "Lean.Parser.Tactic.tacticHave_",
+                                        "args": [
+                                            {"val": "have"},
+                                            {
+                                                "kind": "Lean.Parser.Term.haveDecl",
+                                                "args": [
+                                                    {
+                                                        "kind": "Lean.Parser.Term.haveIdDecl",
+                                                        "args": [
+                                                            {
+                                                                "kind": "Lean.Parser.Term.haveId",
+                                                                "args": [{"val": "h_ok"}],
+                                                            }
+                                                        ],
+                                                    },
+                                                    {"val": ":"},
+                                                    {"val": "True"},
+                                                ],
+                                            },
+                                            {"val": ":="},
+                                            {
+                                                "kind": "Lean.Parser.Term.byTactic",
+                                                "args": [
+                                                    {"val": "by"},
+                                                    {
+                                                        "kind": "Lean.Parser.Tactic.tacticSeq",
+                                                        "args": [
+                                                            {
+                                                                "kind": "Lean.Parser.Tactic.tacticSorry",
+                                                                "args": [{"val": "sorry", "info": {"pos": [0, 5]}}],
+                                                            }
+                                                        ],
+                                                    },
+                                                ],
+                                            },
+                                        ],
+                                    }
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            }
+        ]
+    }
+
+    theorem_state = {
+        "syntactic": True,
+        "errors": "",
+        "preamble": "import Foo",
+        "formal_theorem": "theorem t : True := by trivial",
+        "proof_sketch": "dummy",
+        "ast": {"dummy": True},
+    }
+
+    kimina = _FakeKiminaClient(ast_code_results=[{"error": None, "ast": ast_with_outer_sorry}])
+
+    mod._maybe_flag_downstream_parser_errors(
+        theorem_state=theorem_state,
+        kimina_client=kimina,
+        server_timeout=1,
+        raw_output="theorem t : True := by\n  have h_ok : True := by\n    sorry\n  trivial\n",
+    )
+
+    # Should remain syntactic; the downstream structural checks may return early if target signature
+    # extraction fails under this unit-test Kimina stub, but it must not be rejected by the new guardrail.
+    assert theorem_state["syntactic"] is True
+    assert theorem_state["errors"] == ""
+
+
 def test_proof_checker_flags_structural_extraction_failure(monkeypatch: pytest.MonkeyPatch) -> None:
     """
     If ast_code succeeds but structural extraction fails (extract_proof_body_from_ast returns None),


### PR DESCRIPTION
Reject sketches where a named subgoal's only sorry is inside a structured subproof (e.g. calc step) instead of a top-level placeholder. Such sketches cause reconstruction to fail ("All indentation strategies failed") because the child proof of the named statement cannot be inlined at the nested hole's local goal.

- sketch_checker_agent: add _find_haves_with_only_nested_sorry() to detect the pattern using Kimina AST kinds (Lean.calcTactic, etc.); call from _maybe_flag_downstream_parser_errors() and mark sketch unsyntactic with an actionable error message.
- decomposer-initial/subsequent/backtrack: add prompt constraints telling the LLM to never place sorry inside nested subproofs; require top-level "have h : T := by sorry" for unproven subgoals.
- tests: add test_sketch_checker_rejects_nested_sorry_in_calc_subproof and test_sketch_checker_allows_top_level_sorry_in_have.